### PR TITLE
26.1 port

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         # Use these Java versions
         java: [
-          21,    # Current Java LTS
+          25,    # Current Java LTS
         ]
     runs-on: ubuntu-22.04
     steps:
@@ -24,13 +24,13 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
-          distribution: 'microsoft'
+          distribution: 'temurin'
       - name: make gradle wrapper executable
         run: chmod +x ./gradlew
       - name: build
         run: ./gradlew build
       - name: capture build artifacts
-        if: ${{ matrix.java == '21' }} # Only upload artifacts built from latest java
+        if: ${{ matrix.java == '25' }} # Only upload artifacts built from latest java
         uses: actions/upload-artifact@v4
         with:
           name: Artifacts

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
       - name: Build with Gradle
         uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 1.1.1
 
+- Fix a class-initialisation cycle that could deadlock under parallel registry loading (NeoForge).
 - Minecraft 26.1.2 support (Java 25).
 - Bundle contents are now stored as `ItemStackTemplate`, mirroring vanilla `BundleContents`.
 - `Content.items()` returns `List<ItemStackTemplate>`; use `stream()` / `iterateCopy()` for stacks, `iterate()` is deprecated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 1.1.1
+
+- Minecraft 26.1.2 support (Java 25).
+- Bundle contents are now stored as `ItemStackTemplate`, mirroring vanilla `BundleContents`.
+- `Content.items()` returns `List<ItemStackTemplate>`; use `stream()` / `iterateCopy()` for stacks, `iterate()` is deprecated.
+- Tooltip subclasses override `extractImage` (with `GuiGraphicsExtractor`) instead of `renderImage`.
+- Bundles can supply a custom empty-state tooltip description.
+- Removed the leftover bundle fullness tooltip line.
+
 # 1.1.0
 
 - migrated to Architectury (Thanks Daedelus!)

--- a/README.md
+++ b/README.md
@@ -2,25 +2,29 @@
 
 An API for mods that allows easy addition of bundles with custom sizes and filtered content.
 
+This repository is the **RPG Series fork** of [TheRedBrain's Bundle API](https://github.com/TheRedBrain/bundle-api),
+maintained because upstream stopped at Minecraft 1.21.1. The mod id (`bundleapi`), maven group
+(`com.github.TheRedBrain`) and artifact name (`bundle-api`) are kept unchanged so it stays a drop-in replacement.
+
+Current line: **Minecraft 26.1.x, Java 25**, Fabric + NeoForge (Architectury).
+
 ## Installation
 
-Add this mod as dependency for your project.
+The fork is built and consumed locally — build it with `./gradlew build publishToMavenLocal`, then depend on it
+from `mavenLocal()`:
 
 build.gradle
 
 ```groovy
 repositories {
-    maven {
-        name = 'Modrinth'
-        url = 'https://api.modrinth.com/maven'
-        content {
-            includeGroup 'maven.modrinth'
-        }
-    }
+    mavenLocal()
 }
 
 dependencies {
-    modImplementation "maven.modrinth:bundle-api:${project.bundle_api_version}"
+    // pick the artifact matching your platform module
+    modImplementation "com.github.TheRedBrain:bundle-api-fabric:${project.bundle_api_version}"
+    // or
+    modImplementation "com.github.TheRedBrain:bundle-api-neoforge:${project.bundle_api_version}"
 }
 ```
 
@@ -28,7 +32,7 @@ gradle.properties
 
 ```
 # replace with latest version
-bundle_api_version=1.0.0
+bundle_api_version=1.1.1+26.1.2
 ```
 
 ## Usage
@@ -37,4 +41,5 @@ bundle_api_version=1.0.0
 - Register your item instance.
 - Add model and texture files (taking inspiration from the vanilla bundle is recommended)
 
-A simple example can be found on [GitHub](https://github.com/TheRedBrain/bundle-api/blob/1.21.1/src/testmod/java/com/github/theredbrain/bundleapi_test/BundleAPITest.java).
+A simple example can be found in this repository at
+`fabric/src/testmod/java/com/github/theredbrain/bundleapi_test/BundleAPITest.java`.

--- a/build.gradle
+++ b/build.gradle
@@ -33,10 +33,7 @@ subprojects {
 
     dependencies {
         minecraft "net.minecraft:minecraft:$rootProject.minecraft_version"
-        mappings loom.layered {
-            it.mappings("net.fabricmc:yarn:$rootProject.yarn_mappings:v2")
-            it.mappings("dev.architectury:yarn-mappings-patch-neoforge:$rootProject.yarn_mappings_patch_neoforge_version")
-        }
+        mappings loom.officialMojangMappings()
     }
 
     java {

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
-    id 'dev.architectury.loom' version '1.17-SNAPSHOT' apply false
+    // This version of Minecraft is not obfuscated, so Loom is set up without remapping.
+    id 'dev.architectury.loom-no-remap' version '1.17-SNAPSHOT' apply false
     id 'architectury-plugin' version '3.5-SNAPSHOT'
     id 'com.gradleup.shadow' version '9.4.3' apply false
 }
@@ -8,13 +9,18 @@ architectury {
     minecraft = project.minecraft_version
 }
 
+// Game versions this build is published for, oldest first (colon separated in gradle.properties).
+// The first entry is the manifest minimum, the whole list feeds the CurseForge/Modrinth tags.
+ext.minecraftCompatVersions = rootProject.minecraft_compat_versions.split(':').collect { it.trim() }.findAll { it }
+
 allprojects {
     group = rootProject.maven_group
     version = rootProject.mod_version + "+" + rootProject.minecraft_version
+    ext.minecraft_min_version = rootProject.minecraftCompatVersions.first()
 }
 
 subprojects {
-    apply plugin: 'dev.architectury.loom'
+    apply plugin: 'dev.architectury.loom-no-remap'
     apply plugin: 'architectury-plugin'
     apply plugin: 'maven-publish'
 
@@ -33,7 +39,6 @@ subprojects {
 
     dependencies {
         minecraft "net.minecraft:minecraft:$rootProject.minecraft_version"
-        mappings loom.officialMojangMappings()
     }
 
     java {
@@ -42,15 +47,15 @@ subprojects {
         // If you remove this line, sources will not be generated.
         withSourcesJar()
 
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
+        sourceCompatibility = JavaVersion.VERSION_25
+        targetCompatibility = JavaVersion.VERSION_25
         toolchain {
-            languageVersion = JavaLanguageVersion.of(21)
+            languageVersion = JavaLanguageVersion.of(25)
         }
     }
 
     tasks.withType(JavaCompile).configureEach {
-        it.options.release = 21
+        it.options.release = 25
     }
 
     // Configure Maven publishing.

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -6,5 +6,5 @@ dependencies {
     // We depend on Fabric Loader here to use the Fabric @Environment annotations,
     // which get remapped to the correct annotations on each platform.
     // Do NOT use other classes from Fabric Loader.
-    modImplementation "net.fabricmc:fabric-loader:$rootProject.fabric_loader_version"
+    implementation "net.fabricmc:fabric-loader:$rootProject.fabric_loader_version"
 }

--- a/common/src/main/java/com/github/theredbrain/bundleapi/BundleAPI.java
+++ b/common/src/main/java/com/github/theredbrain/bundleapi/BundleAPI.java
@@ -23,6 +23,46 @@ public class BundleAPI {
 
 	public static void init() {
 		LOGGER.info("Customized Bundles!");
+		registerContainerComponentManipulator();
+	}
+
+	/**
+	 * Publishes our manipulator to vanilla's {@link ContainerComponentManipulators#ALL_MANIPULATORS}.
+	 *
+	 * <p><b>Why this is not done from a static initialiser.</b> {@code BundleAPI.<clinit>} is triggered from
+	 * {@code DataComponentTypesMixin}, which injects at the TAIL of {@code DataComponents.<clinit>} (that inject has to
+	 * stay there - it is the only point that is guaranteed to run inside {@code BuiltInRegistries.createContents()},
+	 * i.e. before {@code freeze()}, on both loaders). Touching {@code ALL_MANIPULATORS} initialises
+	 * {@code ContainerComponentManipulators}, whose map is built with
+	 * {@code Collectors.toMap(ContainerComponentManipulator::type, ...)} and therefore calls {@code type()} on vanilla's
+	 * three manipulators, reading {@code DataComponents.CONTAINER} / {@code BUNDLE_CONTENTS} /
+	 * {@code CHARGED_PROJECTILES} - re-entering a class that is still initialising. Single-threaded the JVM permits that
+	 * (recursive initialisation, and the fields are already assigned at TAIL), but a second thread initialising
+	 * {@code ContainerComponentManipulators} while ours sits inside {@code DataComponents.<clinit>} deadlocks on the two
+	 * class-init monitors. NeoForge 26.1 loads registry elements in parallel, so that race is reachable. Doing the put
+	 * from {@code init()} keeps the dependency one-directional: our thread waits for {@code DataComponents}, and nothing
+	 * ever waits for us.
+	 *
+	 * <p><b>Ordering.</b> {@code init()} runs from each loader's mod entrypoint - {@code FabricMod#onInitialize} (Fabric,
+	 * on {@code main}) and the {@code @Mod} constructor (NeoForge, on a {@code modloading-worker-*} thread). Both run
+	 * after {@code BuiltInRegistries.bootStrap()} - measured on both loaders, {@code DATA_COMPONENT_TYPE} already holds
+	 * its 111 vanilla entries plus ours, and {@code ITEM} its full 1506 - so {@code DataComponents} is fully initialised
+	 * by then and no cycle can form. Both also run before any datapack is read. {@code ALL_MANIPULATORS} is
+	 * only ever consulted lazily, from the {@code ContainerComponentManipulators.CODEC} lambda: when parsing the
+	 * {@code set_contents} / {@code modify_contents} loot functions and {@code ContentsSlotSource} item-model slots. All
+	 * of that happens on the first resource reload - after every mod entrypoint, after registry freeze and after creative
+	 * tabs are built - so the manipulator is always in place before anything can look for it. Registry freeze itself
+	 * never touches the map; only the component registration in {@code DataComponentTypesMixin} has to beat the freeze,
+	 * and that one stays where it is.
+	 */
+	private static void registerContainerComponentManipulator() {
+		// Vanilla's ALL_MANIPULATORS is a plain HashMap (Collectors.toMap), and the field is a final interface constant,
+		// so it cannot be swapped for a ConcurrentHashMap. Fabric calls init() from the single-threaded ModInitializer
+		// dispatch, but NeoForge calls it from a parallel modloading-worker thread, so a single-threaded init point is
+		// NOT guaranteed here: we take the map's own monitor, the only lock concurrent writers could ever agree on.
+		synchronized (ContainerComponentManipulators.ALL_MANIPULATORS) {
+			ContainerComponentManipulators.ALL_MANIPULATORS.put(CUSTOM_BUNDLE_CONTENTS_COMPONENT, CUSTOM_BUNDLE_CONTENTS_CONTAINER_COMPONENT_MODIFIER);
+		}
 	}
 
 	static {
@@ -49,7 +89,9 @@ public class BundleAPI {
 				return builder.build();
 			}
 		};
-		ContainerComponentManipulators.ALL_MANIPULATORS.put(CUSTOM_BUNDLE_CONTENTS_COMPONENT, CUSTOM_BUNDLE_CONTENTS_CONTAINER_COMPONENT_MODIFIER);
+		// NOTE: the ALL_MANIPULATORS registration deliberately does NOT happen here - see
+		// registerContainerComponentManipulator(). This static block is reached from DataComponents.<clinit> and must not
+		// initialise ContainerComponentManipulators.
 	}
 
 	public static Identifier identifier(String path) {

--- a/common/src/main/java/com/github/theredbrain/bundleapi/BundleAPI.java
+++ b/common/src/main/java/com/github/theredbrain/bundleapi/BundleAPI.java
@@ -2,57 +2,57 @@ package com.github.theredbrain.bundleapi;
 
 import com.github.theredbrain.bundleapi.component.type.CustomBundleContentsComponent;
 import com.github.theredbrain.bundleapi.predicate.item.CustomBundleContentsPredicate;
-import net.minecraft.component.ComponentType;
-import net.minecraft.item.ItemStack;
-import net.minecraft.loot.ContainerComponentModifier;
-import net.minecraft.loot.ContainerComponentModifiers;
-import net.minecraft.predicate.component.ComponentPredicate;
-import net.minecraft.util.Identifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.stream.Stream;
+import net.minecraft.core.component.DataComponentType;
+import net.minecraft.core.component.predicates.DataComponentPredicate;
+import net.minecraft.resources.Identifier;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.storage.loot.ContainerComponentManipulator;
+import net.minecraft.world.level.storage.loot.ContainerComponentManipulators;
 
 public class BundleAPI {
 	public static final String MOD_ID = "bundleapi";
 	public static final Logger LOGGER = LoggerFactory.getLogger(MOD_ID);
 
-	public static ComponentType<CustomBundleContentsComponent> CUSTOM_BUNDLE_CONTENTS_COMPONENT = ComponentType.<CustomBundleContentsComponent>builder().codec(CustomBundleContentsComponent.CODEC).packetCodec(CustomBundleContentsComponent.PACKET_CODEC).cache().build();
-	public static ComponentPredicate.Type<CustomBundleContentsPredicate> CUSTOM_BUNDLE_CONTENTS_ITEM_SUB_PREDICATE = new ComponentPredicate.OfValue<>(CustomBundleContentsPredicate.CODEC);
-	public static ContainerComponentModifier<CustomBundleContentsComponent> CUSTOM_BUNDLE_CONTENTS_CONTAINER_COMPONENT_MODIFIER;
+	public static DataComponentType<CustomBundleContentsComponent> CUSTOM_BUNDLE_CONTENTS_COMPONENT = DataComponentType.<CustomBundleContentsComponent>builder().persistent(CustomBundleContentsComponent.CODEC).networkSynchronized(CustomBundleContentsComponent.PACKET_CODEC).cacheEncoding().build();
+	public static DataComponentPredicate.Type<CustomBundleContentsPredicate> CUSTOM_BUNDLE_CONTENTS_ITEM_SUB_PREDICATE = new DataComponentPredicate.ConcreteType<>(CustomBundleContentsPredicate.CODEC);
+	public static ContainerComponentManipulator<CustomBundleContentsComponent> CUSTOM_BUNDLE_CONTENTS_CONTAINER_COMPONENT_MODIFIER;
 
 	public static void init() {
 		LOGGER.info("Customized Bundles!");
 	}
 
 	static {
-		CUSTOM_BUNDLE_CONTENTS_CONTAINER_COMPONENT_MODIFIER = new ContainerComponentModifier<CustomBundleContentsComponent>() {
+		CUSTOM_BUNDLE_CONTENTS_CONTAINER_COMPONENT_MODIFIER = new ContainerComponentManipulator<CustomBundleContentsComponent>() {
 			@Override
-			public ComponentType<CustomBundleContentsComponent> getComponentType() {
+			public DataComponentType<CustomBundleContentsComponent> type() {
 				return CUSTOM_BUNDLE_CONTENTS_COMPONENT;
 			}
 
 			@Override
-			public CustomBundleContentsComponent getDefault() {
+			public CustomBundleContentsComponent empty() {
 				return CustomBundleContentsComponent.DEFAULT;
 			}
 
 			@Override
-			public Stream<ItemStack> stream(CustomBundleContentsComponent customBundleContentsComponent) {
+			public Stream<ItemStack> getContents(CustomBundleContentsComponent customBundleContentsComponent) {
 				return customBundleContentsComponent.stream();
 			}
 
 			@Override
-			public CustomBundleContentsComponent apply(CustomBundleContentsComponent customBundleContentsComponent, Stream<ItemStack> stream) {
+			public CustomBundleContentsComponent setContents(CustomBundleContentsComponent customBundleContentsComponent, Stream<ItemStack> stream) {
 				CustomBundleContentsComponent.Builder builder = new CustomBundleContentsComponent.Builder(customBundleContentsComponent).clear();
 				stream.forEach(builder::add);
 				return builder.build();
 			}
 		};
-		ContainerComponentModifiers.TYPE_TO_MODIFIER.put(CUSTOM_BUNDLE_CONTENTS_COMPONENT, CUSTOM_BUNDLE_CONTENTS_CONTAINER_COMPONENT_MODIFIER);
+		ContainerComponentManipulators.ALL_MANIPULATORS.put(CUSTOM_BUNDLE_CONTENTS_COMPONENT, CUSTOM_BUNDLE_CONTENTS_CONTAINER_COMPONENT_MODIFIER);
 	}
 
 	public static Identifier identifier(String path) {
-		return Identifier.of(MOD_ID, path);
+		return Identifier.fromNamespaceAndPath(MOD_ID, path);
 	}
 }

--- a/common/src/main/java/com/github/theredbrain/bundleapi/client/gui/tooltip/CustomBundleTooltipComponent.java
+++ b/common/src/main/java/com/github/theredbrain/bundleapi/client/gui/tooltip/CustomBundleTooltipComponent.java
@@ -2,29 +2,29 @@ package com.github.theredbrain.bundleapi.client.gui.tooltip;
 
 import com.github.theredbrain.bundleapi.component.type.CustomBundleContentsComponent;
 import com.github.theredbrain.bundleapi.item.tooltip.CustomBundleTooltipData;
-import net.minecraft.client.font.TextRenderer;
-import net.minecraft.client.gl.RenderPipelines;
-import net.minecraft.client.gui.DrawContext;
-import net.minecraft.client.gui.tooltip.TooltipComponent;
-import net.minecraft.item.ItemStack;
-import net.minecraft.text.Text;
-import net.minecraft.util.Identifier;
-import net.minecraft.util.math.MathHelper;
 import org.apache.commons.lang3.math.Fraction;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.screens.inventory.tooltip.ClientTooltipComponent;
+import net.minecraft.client.renderer.RenderPipelines;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.Identifier;
+import net.minecraft.util.Mth;
+import net.minecraft.world.item.ItemStack;
 
 /**
  * Mirrors vanilla {@code BundleTooltipComponent} (1.21.4+ bundle tooltip layout: a grid of
  * 24x24 slots plus an occupancy progress bar), but reads a {@link CustomBundleContentsComponent}.
  * Unlike vanilla bundles, custom bundles have no "selected stack", so no selection highlight is drawn.
  */
-public class CustomBundleTooltipComponent implements TooltipComponent {
-	private static final Identifier BUNDLE_PROGRESS_BAR_BORDER_TEXTURE = Identifier.ofVanilla("container/bundle/bundle_progressbar_border");
-	private static final Identifier BUNDLE_PROGRESS_BAR_FILL_TEXTURE = Identifier.ofVanilla("container/bundle/bundle_progressbar_fill");
-	private static final Identifier BUNDLE_PROGRESS_BAR_FULL_TEXTURE = Identifier.ofVanilla("container/bundle/bundle_progressbar_full");
-	private static final Identifier BUNDLE_SLOT_BACKGROUND_TEXTURE = Identifier.ofVanilla("container/bundle/slot_background");
+public class CustomBundleTooltipComponent implements ClientTooltipComponent {
+	private static final Identifier BUNDLE_PROGRESS_BAR_BORDER_TEXTURE = Identifier.withDefaultNamespace("container/bundle/bundle_progressbar_border");
+	private static final Identifier BUNDLE_PROGRESS_BAR_FILL_TEXTURE = Identifier.withDefaultNamespace("container/bundle/bundle_progressbar_fill");
+	private static final Identifier BUNDLE_PROGRESS_BAR_FULL_TEXTURE = Identifier.withDefaultNamespace("container/bundle/bundle_progressbar_full");
+	private static final Identifier BUNDLE_SLOT_BACKGROUND_TEXTURE = Identifier.withDefaultNamespace("container/bundle/slot_background");
 	private static final int SLOTS_PER_ROW = 4;
 	private static final int SLOT_DIMENSION = 24;
 	private static final int ROW_WIDTH = 96;
@@ -32,12 +32,12 @@ public class CustomBundleTooltipComponent implements TooltipComponent {
 	private static final int PROGRESS_BAR_WIDTH = 94;
 	private static final int MAX_SLOTS_SHOWN = 12;
 	private static final int MAX_SLOTS_SHOWN_WHEN_TOO_MANY_TYPES = 11;
-	private static final Text BUNDLE_FULL = Text.translatable("item.minecraft.bundle.full");
-	private static final Text BUNDLE_EMPTY = Text.translatable("item.minecraft.bundle.empty");
+	private static final Component BUNDLE_FULL = Component.translatable("item.minecraft.bundle.full");
+	private static final Component BUNDLE_EMPTY = Component.translatable("item.minecraft.bundle.empty");
 	private final CustomBundleContentsComponent customBundleContents;
-	private final Text emptyDescription;
+	private final Component emptyDescription;
 
-	public CustomBundleTooltipComponent(CustomBundleContentsComponent customBundleContents, Text emptyDescription) {
+	public CustomBundleTooltipComponent(CustomBundleContentsComponent customBundleContents, Component emptyDescription) {
 		this.customBundleContents = customBundleContents;
 		this.emptyDescription = emptyDescription;
 	}
@@ -51,21 +51,21 @@ public class CustomBundleTooltipComponent implements TooltipComponent {
 	}
 
 	@Override
-	public int getHeight(TextRenderer textRenderer) {
+	public int getHeight(Font textRenderer) {
 		return this.customBundleContents.isEmpty() ? this.getHeightOfEmpty(textRenderer) : this.getHeightOfNonEmpty();
 	}
 
 	@Override
-	public int getWidth(TextRenderer textRenderer) {
+	public int getWidth(Font textRenderer) {
 		return ROW_WIDTH;
 	}
 
 	@Override
-	public boolean isSticky() {
+	public boolean showTooltipWithItemInHand() {
 		return true;
 	}
 
-	private int getHeightOfEmpty(TextRenderer textRenderer) {
+	private int getHeightOfEmpty(Font textRenderer) {
 		return this.getDescriptionHeight(textRenderer) + PROGRESS_BAR_HEIGHT + 8;
 	}
 
@@ -82,7 +82,7 @@ public class CustomBundleTooltipComponent implements TooltipComponent {
 	}
 
 	private int getRows() {
-		return MathHelper.ceilDiv(this.getNumVisibleSlots(), SLOTS_PER_ROW);
+		return Mth.positiveCeilDiv(this.getNumVisibleSlots(), SLOTS_PER_ROW);
 	}
 
 	private int getNumVisibleSlots() {
@@ -101,7 +101,7 @@ public class CustomBundleTooltipComponent implements TooltipComponent {
 	}
 
 	@Override
-	public void drawItems(TextRenderer textRenderer, int x, int y, int width, int height, DrawContext context) {
+	public void renderImage(Font textRenderer, int x, int y, int width, int height, GuiGraphics context) {
 		if (this.customBundleContents.isEmpty()) {
 			this.drawEmptyTooltip(textRenderer, x, y, width, context);
 		} else {
@@ -109,12 +109,12 @@ public class CustomBundleTooltipComponent implements TooltipComponent {
 		}
 	}
 
-	private void drawEmptyTooltip(TextRenderer textRenderer, int x, int y, int width, DrawContext context) {
+	private void drawEmptyTooltip(Font textRenderer, int x, int y, int width, GuiGraphics context) {
 		this.drawEmptyDescription(x + this.getXMargin(width), y, textRenderer, context);
 		this.drawProgressBar(x + this.getXMargin(width), y + this.getDescriptionHeight(textRenderer) + 4, textRenderer, context);
 	}
 
-	private void drawNonEmptyTooltip(TextRenderer textRenderer, int x, int y, int width, DrawContext context) {
+	private void drawNonEmptyTooltip(Font textRenderer, int x, int y, int width, GuiGraphics context) {
 		boolean bl = this.customBundleContents.size() > MAX_SLOTS_SHOWN;
 		List<ItemStack> list = this.firstStacksInContents(this.getNumberOfStacksShown());
 		int i = x + this.getXMargin(width) + ROW_WIDTH;
@@ -154,37 +154,37 @@ public class CustomBundleTooltipComponent implements TooltipComponent {
 		return this.customBundleContents.stream().skip(items.size()).mapToInt(ItemStack::getCount).sum();
 	}
 
-	private static void drawItem(int index, int x, int y, List<ItemStack> stacks, int seed, TextRenderer textRenderer, DrawContext drawContext) {
+	private static void drawItem(int index, int x, int y, List<ItemStack> stacks, int seed, Font textRenderer, GuiGraphics drawContext) {
 		int i = stacks.size() - index;
 		ItemStack itemStack = stacks.get(i);
-		drawContext.drawGuiTexture(RenderPipelines.GUI_TEXTURED, BUNDLE_SLOT_BACKGROUND_TEXTURE, x, y, SLOT_DIMENSION, SLOT_DIMENSION);
-		drawContext.drawItem(itemStack, x + 4, y + 4, seed);
-		drawContext.drawStackOverlay(textRenderer, itemStack, x + 4, y + 4);
+		drawContext.blitSprite(RenderPipelines.GUI_TEXTURED, BUNDLE_SLOT_BACKGROUND_TEXTURE, x, y, SLOT_DIMENSION, SLOT_DIMENSION);
+		drawContext.renderItem(itemStack, x + 4, y + 4, seed);
+		drawContext.renderItemDecorations(textRenderer, itemStack, x + 4, y + 4);
 	}
 
-	private static void drawExtraItemsCount(int x, int y, int numExtra, TextRenderer textRenderer, DrawContext drawContext) {
-		drawContext.drawCenteredTextWithShadow(textRenderer, "+" + numExtra, x + 12, y + 10, -1);
+	private static void drawExtraItemsCount(int x, int y, int numExtra, Font textRenderer, GuiGraphics drawContext) {
+		drawContext.drawCenteredString(textRenderer, "+" + numExtra, x + 12, y + 10, -1);
 	}
 
-	private void drawProgressBar(int x, int y, TextRenderer textRenderer, DrawContext drawContext) {
-		drawContext.drawGuiTexture(RenderPipelines.GUI_TEXTURED, this.getProgressBarFillTexture(), x + 1, y, this.getProgressBarFill(), PROGRESS_BAR_HEIGHT);
-		drawContext.drawGuiTexture(RenderPipelines.GUI_TEXTURED, BUNDLE_PROGRESS_BAR_BORDER_TEXTURE, x, y, ROW_WIDTH, PROGRESS_BAR_HEIGHT);
-		Text text = this.getProgressBarLabel();
+	private void drawProgressBar(int x, int y, Font textRenderer, GuiGraphics drawContext) {
+		drawContext.blitSprite(RenderPipelines.GUI_TEXTURED, this.getProgressBarFillTexture(), x + 1, y, this.getProgressBarFill(), PROGRESS_BAR_HEIGHT);
+		drawContext.blitSprite(RenderPipelines.GUI_TEXTURED, BUNDLE_PROGRESS_BAR_BORDER_TEXTURE, x, y, ROW_WIDTH, PROGRESS_BAR_HEIGHT);
+		Component text = this.getProgressBarLabel();
 		if (text != null) {
-			drawContext.drawCenteredTextWithShadow(textRenderer, text, x + 48, y + 3, -1);
+			drawContext.drawCenteredString(textRenderer, text, x + 48, y + 3, -1);
 		}
 	}
 
-	private void drawEmptyDescription(int x, int y, TextRenderer textRenderer, DrawContext drawContext) {
-		drawContext.drawWrappedTextWithShadow(textRenderer, this.emptyDescription, x, y, ROW_WIDTH, -5592406);
+	private void drawEmptyDescription(int x, int y, Font textRenderer, GuiGraphics drawContext) {
+		drawContext.drawWordWrap(textRenderer, this.emptyDescription, x, y, ROW_WIDTH, -5592406);
 	}
 
-	private int getDescriptionHeight(TextRenderer textRenderer) {
-		return textRenderer.wrapLines(this.emptyDescription, ROW_WIDTH).size() * 9;
+	private int getDescriptionHeight(Font textRenderer) {
+		return textRenderer.split(this.emptyDescription, ROW_WIDTH).size() * 9;
 	}
 
 	private int getProgressBarFill() {
-		return MathHelper.clamp(MathHelper.multiplyFraction(this.customBundleContents.getOccupancy(), PROGRESS_BAR_WIDTH), 0, PROGRESS_BAR_WIDTH);
+		return Mth.clamp(Mth.mulAndTruncate(this.customBundleContents.getOccupancy(), PROGRESS_BAR_WIDTH), 0, PROGRESS_BAR_WIDTH);
 	}
 
 	private Identifier getProgressBarFillTexture() {
@@ -192,7 +192,7 @@ public class CustomBundleTooltipComponent implements TooltipComponent {
 	}
 
 	@Nullable
-	private Text getProgressBarLabel() {
+	private Component getProgressBarLabel() {
 		if (this.customBundleContents.isEmpty()) {
 			return BUNDLE_EMPTY;
 		} else {

--- a/common/src/main/java/com/github/theredbrain/bundleapi/client/gui/tooltip/CustomBundleTooltipComponent.java
+++ b/common/src/main/java/com/github/theredbrain/bundleapi/client/gui/tooltip/CustomBundleTooltipComponent.java
@@ -3,11 +3,11 @@ package com.github.theredbrain.bundleapi.client.gui.tooltip;
 import com.github.theredbrain.bundleapi.component.type.CustomBundleContentsComponent;
 import com.github.theredbrain.bundleapi.item.tooltip.CustomBundleTooltipData;
 import org.apache.commons.lang3.math.Fraction;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 import net.minecraft.client.gui.Font;
-import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.screens.inventory.tooltip.ClientTooltipComponent;
 import net.minecraft.client.renderer.RenderPipelines;
 import net.minecraft.network.chat.Component;
@@ -16,8 +16,9 @@ import net.minecraft.util.Mth;
 import net.minecraft.world.item.ItemStack;
 
 /**
- * Mirrors vanilla {@code BundleTooltipComponent} (1.21.4+ bundle tooltip layout: a grid of
- * 24x24 slots plus an occupancy progress bar), but reads a {@link CustomBundleContentsComponent}.
+ * Mirrors vanilla {@code ClientBundleTooltip} (1.21.4+ bundle tooltip layout: a grid of
+ * 24x24 slots plus an occupancy progress bar, extracted through {@link GuiGraphicsExtractor} since 26.1),
+ * but reads a {@link CustomBundleContentsComponent}.
  * Unlike vanilla bundles, custom bundles have no "selected stack", so no selection highlight is drawn.
  */
 public class CustomBundleTooltipComponent implements ClientTooltipComponent {
@@ -101,7 +102,7 @@ public class CustomBundleTooltipComponent implements ClientTooltipComponent {
 	}
 
 	@Override
-	public void renderImage(Font textRenderer, int x, int y, int width, int height, GuiGraphics context) {
+	public void extractImage(Font textRenderer, int x, int y, int width, int height, GuiGraphicsExtractor context) {
 		if (this.customBundleContents.isEmpty()) {
 			this.drawEmptyTooltip(textRenderer, x, y, width, context);
 		} else {
@@ -109,12 +110,12 @@ public class CustomBundleTooltipComponent implements ClientTooltipComponent {
 		}
 	}
 
-	private void drawEmptyTooltip(Font textRenderer, int x, int y, int width, GuiGraphics context) {
+	private void drawEmptyTooltip(Font textRenderer, int x, int y, int width, GuiGraphicsExtractor context) {
 		this.drawEmptyDescription(x + this.getXMargin(width), y, textRenderer, context);
 		this.drawProgressBar(x + this.getXMargin(width), y + this.getDescriptionHeight(textRenderer) + 4, textRenderer, context);
 	}
 
-	private void drawNonEmptyTooltip(Font textRenderer, int x, int y, int width, GuiGraphics context) {
+	private void drawNonEmptyTooltip(Font textRenderer, int x, int y, int width, GuiGraphicsExtractor context) {
 		boolean bl = this.customBundleContents.size() > MAX_SLOTS_SHOWN;
 		List<ItemStack> list = this.firstStacksInContents(this.getNumberOfStacksShown());
 		int i = x + this.getXMargin(width) + ROW_WIDTH;
@@ -154,29 +155,29 @@ public class CustomBundleTooltipComponent implements ClientTooltipComponent {
 		return this.customBundleContents.stream().skip(items.size()).mapToInt(ItemStack::getCount).sum();
 	}
 
-	private static void drawItem(int index, int x, int y, List<ItemStack> stacks, int seed, Font textRenderer, GuiGraphics drawContext) {
+	private static void drawItem(int index, int x, int y, List<ItemStack> stacks, int seed, Font textRenderer, GuiGraphicsExtractor drawContext) {
 		int i = stacks.size() - index;
 		ItemStack itemStack = stacks.get(i);
 		drawContext.blitSprite(RenderPipelines.GUI_TEXTURED, BUNDLE_SLOT_BACKGROUND_TEXTURE, x, y, SLOT_DIMENSION, SLOT_DIMENSION);
-		drawContext.renderItem(itemStack, x + 4, y + 4, seed);
-		drawContext.renderItemDecorations(textRenderer, itemStack, x + 4, y + 4);
+		drawContext.item(itemStack, x + 4, y + 4, seed);
+		drawContext.itemDecorations(textRenderer, itemStack, x + 4, y + 4);
 	}
 
-	private static void drawExtraItemsCount(int x, int y, int numExtra, Font textRenderer, GuiGraphics drawContext) {
-		drawContext.drawCenteredString(textRenderer, "+" + numExtra, x + 12, y + 10, -1);
+	private static void drawExtraItemsCount(int x, int y, int numExtra, Font textRenderer, GuiGraphicsExtractor drawContext) {
+		drawContext.centeredText(textRenderer, "+" + numExtra, x + 12, y + 10, -1);
 	}
 
-	private void drawProgressBar(int x, int y, Font textRenderer, GuiGraphics drawContext) {
+	private void drawProgressBar(int x, int y, Font textRenderer, GuiGraphicsExtractor drawContext) {
 		drawContext.blitSprite(RenderPipelines.GUI_TEXTURED, this.getProgressBarFillTexture(), x + 1, y, this.getProgressBarFill(), PROGRESS_BAR_HEIGHT);
 		drawContext.blitSprite(RenderPipelines.GUI_TEXTURED, BUNDLE_PROGRESS_BAR_BORDER_TEXTURE, x, y, ROW_WIDTH, PROGRESS_BAR_HEIGHT);
 		Component text = this.getProgressBarLabel();
 		if (text != null) {
-			drawContext.drawCenteredString(textRenderer, text, x + 48, y + 3, -1);
+			drawContext.centeredText(textRenderer, text, x + 48, y + 3, -1);
 		}
 	}
 
-	private void drawEmptyDescription(int x, int y, Font textRenderer, GuiGraphics drawContext) {
-		drawContext.drawWordWrap(textRenderer, this.emptyDescription, x, y, ROW_WIDTH, -5592406);
+	private void drawEmptyDescription(int x, int y, Font textRenderer, GuiGraphicsExtractor drawContext) {
+		drawContext.textWithWordWrap(textRenderer, this.emptyDescription, x, y, ROW_WIDTH, -5592406);
 	}
 
 	private int getDescriptionHeight(Font textRenderer) {
@@ -191,8 +192,7 @@ public class CustomBundleTooltipComponent implements ClientTooltipComponent {
 		return this.customBundleContents.getOccupancy().compareTo(Fraction.ONE) >= 0 ? BUNDLE_PROGRESS_BAR_FULL_TEXTURE : BUNDLE_PROGRESS_BAR_FILL_TEXTURE;
 	}
 
-	@Nullable
-	private Component getProgressBarLabel() {
+	private @Nullable Component getProgressBarLabel() {
 		if (this.customBundleContents.isEmpty()) {
 			return BUNDLE_EMPTY;
 		} else {

--- a/common/src/main/java/com/github/theredbrain/bundleapi/client/render/item/property/numeric/CustomBundleFullnessProperty.java
+++ b/common/src/main/java/com/github/theredbrain/bundleapi/client/render/item/property/numeric/CustomBundleFullnessProperty.java
@@ -6,7 +6,7 @@ import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.renderer.item.properties.numeric.RangeSelectItemModelProperty;
 import net.minecraft.world.entity.ItemOwner;
 import net.minecraft.world.item.ItemStack;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Item model numeric property {@code bundleapi:custom_bundle/fullness}.

--- a/common/src/main/java/com/github/theredbrain/bundleapi/client/render/item/property/numeric/CustomBundleFullnessProperty.java
+++ b/common/src/main/java/com/github/theredbrain/bundleapi/client/render/item/property/numeric/CustomBundleFullnessProperty.java
@@ -2,10 +2,10 @@ package com.github.theredbrain.bundleapi.client.render.item.property.numeric;
 
 import com.github.theredbrain.bundleapi.item.CustomBundleItem;
 import com.mojang.serialization.MapCodec;
-import net.minecraft.client.render.item.property.numeric.NumericProperty;
-import net.minecraft.client.world.ClientWorld;
-import net.minecraft.item.ItemStack;
-import net.minecraft.util.HeldItemContext;
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.client.renderer.item.properties.numeric.RangeSelectItemModelProperty;
+import net.minecraft.world.entity.ItemOwner;
+import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -15,16 +15,16 @@ import org.jetbrains.annotations.Nullable;
  * an item model definition under {@code assets/<namespace>/items/<item>.json} using
  * {@code {"type":"minecraft:range_dispatch","property":"bundleapi:custom_bundle/fullness", ...}}.
  */
-public record CustomBundleFullnessProperty() implements NumericProperty {
+public record CustomBundleFullnessProperty() implements RangeSelectItemModelProperty {
 	public static final MapCodec<CustomBundleFullnessProperty> CODEC = MapCodec.unit(new CustomBundleFullnessProperty());
 
 	@Override
-	public float getValue(ItemStack stack, @Nullable ClientWorld world, @Nullable HeldItemContext context, int seed) {
+	public float get(ItemStack stack, @Nullable ClientLevel world, @Nullable ItemOwner context, int seed) {
 		return CustomBundleItem.getAmountFilled(stack);
 	}
 
 	@Override
-	public MapCodec<CustomBundleFullnessProperty> getCodec() {
+	public MapCodec<CustomBundleFullnessProperty> type() {
 		return CODEC;
 	}
 }

--- a/common/src/main/java/com/github/theredbrain/bundleapi/component/type/CustomBundleContentsComponent.java
+++ b/common/src/main/java/com/github/theredbrain/bundleapi/component/type/CustomBundleContentsComponent.java
@@ -1,11 +1,12 @@
 package com.github.theredbrain.bundleapi.component.type;
 
 import com.github.theredbrain.bundleapi.BundleAPI;
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import org.apache.commons.lang3.math.Fraction;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -17,12 +18,25 @@ import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.inventory.tooltip.TooltipComponent;
+import net.minecraft.world.item.ItemInstance;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.ItemStackTemplate;
 import net.minecraft.world.item.component.Bees;
+import net.minecraft.world.item.component.BundleContents;
 import net.minecraft.world.level.block.entity.BeehiveBlockEntity;
 
+/**
+ * Mirrors vanilla {@link BundleContents} (26.1: stored as immutable {@link ItemStackTemplate}s, because no
+ * {@link ItemStack} may exist before registries load), extended with a {@code size_multiplier} that scales the
+ * capacity. The occupancy is computed from the templates when the component is created and is {@link Fraction#ONE}
+ * ("full") when the weight cannot be computed (vanilla treats an errored weight the same way for display).
+ *
+ * @param content         the stored items, most recently inserted first
+ * @param occupancy       the fraction of the bundle that is used, in {@code [0, 1]}
+ * @param size_multiplier capacity multiplier relative to a vanilla bundle
+ */
 public record CustomBundleContentsComponent(Content content, Fraction occupancy/*, Optional<RegistryEntryList<Item>> tag  TODO add tag key in 1.21.4*/, int size_multiplier) implements TooltipComponent {
-	public static final CustomBundleContentsComponent DEFAULT = new CustomBundleContentsComponent(List.of()/*, Optional.empty()*/, 1);
+	public static final CustomBundleContentsComponent DEFAULT = new CustomBundleContentsComponent(Content.DEFAULT, Fraction.ZERO/*, Optional.empty()*/, 1);
 	public static final Codec<CustomBundleContentsComponent> CODEC = RecordCodecBuilder.create(
 			instance -> instance.group(
 							CustomBundleContentsComponent.Content.CODEC.fieldOf("content").forGetter(component -> component.content),
@@ -49,64 +63,98 @@ public record CustomBundleContentsComponent(Content content, Fraction occupancy/
 		this.size_multiplier = size_multiplier;
 	}
 
-	CustomBundleContentsComponent(List<ItemStack> stacks, Fraction occupancy/*, Optional<RegistryEntryList<Item>> tag*/, int size_multiplier) {
-		this(new Content(stacks), occupancy/*, tag*/, size_multiplier);
-	}
-
-	CustomBundleContentsComponent(List<ItemStack> stacks/*, Optional<RegistryEntryList<Item>> tag*/, int size_multiplier) {
-		this(new Content(stacks), calculateOccupancy(stacks, size_multiplier)/*, tag*/, size_multiplier);
-	}
-
 	public CustomBundleContentsComponent(Content content/*, Optional<RegistryEntryList<Item>> tag*/, int size_multiplier) {
-		this(content, calculateOccupancy(content.stacks, size_multiplier)/*, tag*/, size_multiplier);
+		this(content, calculateOccupancySafe(content.items, size_multiplier)/*, tag*/, size_multiplier);
 	}
 
 	public CustomBundleContentsComponent(/*Optional<RegistryEntryList<Item>> tag, */int size_multiplier) {
-		this(Content.DEFAULT/*, calculateOccupancy(List.of(), size_multiplier)*//*, tag*/, size_multiplier);
+		this(Content.DEFAULT, Fraction.ZERO/*, tag*/, size_multiplier);
 	}
 
 	public static CustomBundleContentsComponent.Builder builder() {
 		return new CustomBundleContentsComponent.Builder(DEFAULT);
 	}
 
-	private static Fraction calculateOccupancy(List<ItemStack> stacks, int size_multiplier) {
-		Fraction fraction = Fraction.ZERO;
-
-		for (ItemStack itemStack : stacks) {
-			fraction = fraction.add(getOccupancy(itemStack, size_multiplier).multiplyBy(Fraction.getFraction(itemStack.getCount(), 1)));
-		}
-
-		return fraction;
+	private static Fraction calculateOccupancySafe(List<? extends ItemInstance> items, int size_multiplier) {
+		return calculateOccupancy(items, size_multiplier).result().orElse(Fraction.ONE);
 	}
 
-	static Fraction getOccupancy(ItemStack stack, int size_multiplier) {
-		CustomBundleContentsComponent customBundleContentsComponent = stack.get(BundleAPI.CUSTOM_BUNDLE_CONTENTS_COMPONENT);
+	/**
+	 * Mirrors {@code BundleContents#computeContentWeight}.
+	 */
+	private static DataResult<Fraction> calculateOccupancy(List<? extends ItemInstance> items, int size_multiplier) {
+		try {
+			Fraction fraction = Fraction.ZERO;
+
+			for (ItemInstance item : items) {
+				DataResult<Fraction> itemOccupancy = getOccupancy(item, size_multiplier);
+				if (itemOccupancy.isError()) {
+					return itemOccupancy;
+				}
+
+				fraction = fraction.add(itemOccupancy.getOrThrow().multiplyBy(Fraction.getFraction(item.count(), 1)));
+			}
+
+			return DataResult.success(fraction);
+		} catch (ArithmeticException exception) {
+			return DataResult.error(() -> "Excessive total bundle weight");
+		}
+	}
+
+	/**
+	 * Mirrors {@code BundleContents#getWeight}: the occupancy of a single item of the given instance.
+	 */
+	static DataResult<Fraction> getOccupancy(ItemInstance item, int size_multiplier) {
+		CustomBundleContentsComponent customBundleContentsComponent = item.get(BundleAPI.CUSTOM_BUNDLE_CONTENTS_COMPONENT);
 		if (customBundleContentsComponent != null) {
-			return NESTED_BUNDLE_OCCUPANCY.add(customBundleContentsComponent.getOccupancy());
-		} else {
-			List<BeehiveBlockEntity.Occupant> list = stack.getOrDefault(DataComponents.BEES, Bees.EMPTY).bees();
-			return !list.isEmpty() ? Fraction.ONE : Fraction.getFraction(1, stack.getMaxStackSize() * size_multiplier);
+			return DataResult.success(NESTED_BUNDLE_OCCUPANCY.add(customBundleContentsComponent.getOccupancy()));
 		}
+
+		BundleContents bundleContents = item.get(DataComponents.BUNDLE_CONTENTS);
+		if (bundleContents != null) {
+			return bundleContents.weight().map(nested -> nested.add(NESTED_BUNDLE_OCCUPANCY));
+		}
+
+		List<BeehiveBlockEntity.Occupant> list = item.getOrDefault(DataComponents.BEES, Bees.EMPTY).bees();
+		return !list.isEmpty() ? BundleContents.BEEHIVE_WEIGHT : DataResult.success(Fraction.getFraction(1, item.getMaxStackSize() * size_multiplier));
 	}
 
+	/**
+	 * @return a fresh {@link ItemStack} created from the template at {@code index}
+	 */
 	public ItemStack get(int index) {
-		return (ItemStack) this.content.stacks.get(index);
+		return this.content.items.get(index).create();
 	}
 
+	/**
+	 * The stored item templates, most recently inserted first. Mirrors {@link BundleContents#items()}.
+	 */
+	public List<ItemStackTemplate> items() {
+		return this.content.items;
+	}
+
+	/**
+	 * Fresh stacks created from the templates. Mirrors {@link BundleContents#itemCopyStream()}.
+	 */
 	public Stream<ItemStack> stream() {
-		return this.content.stacks.stream().map(ItemStack::copy);
+		return this.content.items.stream().map(ItemStackTemplate::create);
 	}
 
+	/**
+	 * @deprecated the contents are immutable templates since 26.1; use {@link #items()} for the templates or
+	 * {@link #stream()} / {@link #iterateCopy()} for stacks. Both iterate methods now create fresh stacks.
+	 */
+	@Deprecated
 	public Iterable<ItemStack> iterate() {
-		return this.content.stacks;
+		return this.iterateCopy();
 	}
 
 	public Iterable<ItemStack> iterateCopy() {
-		return Lists.<ItemStack, ItemStack>transform(this.content.stacks, ItemStack::copy);
+		return this.stream().toList();
 	}
 
 	public int size() {
-		return this.content.stacks.size();
+		return this.content.items.size();
 	}
 
 	public int sizeMultiplier() {
@@ -118,24 +166,31 @@ public record CustomBundleContentsComponent(Content content, Fraction occupancy/
 	}
 
 	public boolean isEmpty() {
-		return this.content.stacks.isEmpty();
+		return this.content.items.isEmpty();
 	}
 
+	/**
+	 * Mirrors {@link BundleContents.Mutable}: works on mutable {@link ItemStack}s and converts back to templates in
+	 * {@link #build()}.
+	 */
 	public static class Builder {
-		private CustomBundleContentsComponent.Content content;
+		private final List<ItemStack> stacks;
 		private Fraction occupancy;
 		//		private Optional<RegistryEntryList<Item>> tag;
 		private int size_multiplier;
 
 		public Builder(CustomBundleContentsComponent base) {
-			this.content = new CustomBundleContentsComponent.Content(base.content.stacks);
+			this.stacks = new ArrayList<>(base.content.items.size());
+			for (ItemStackTemplate item : base.content.items) {
+				this.stacks.add(item.create());
+			}
 			this.occupancy = base.occupancy;
 //			this.tag = base.tag;
 			this.size_multiplier = base.size_multiplier;
 		}
 
 		public CustomBundleContentsComponent.Builder clear() {
-			this.content.stacks.clear();
+			this.stacks.clear();
 			this.occupancy = Fraction.ZERO;
 			return this;
 		}
@@ -144,8 +199,8 @@ public record CustomBundleContentsComponent(Content content, Fraction occupancy/
 			if (!stack.isStackable()) {
 				return -1;
 			} else {
-				for (int i = 0; i < this.content.stacks.size(); i++) {
-					if (ItemStack.isSameItemSameComponents((ItemStack) this.content.stacks.get(i), stack) && this.content.stacks.get(i).getCount() < this.content.stacks.get(i).getMaxStackSize()) {
+				for (int i = 0; i < this.stacks.size(); i++) {
+					if (ItemStack.isSameItemSameComponents(this.stacks.get(i), stack) && this.stacks.get(i).getCount() < this.stacks.get(i).getMaxStackSize()) {
 						return i;
 					}
 				}
@@ -154,38 +209,44 @@ public record CustomBundleContentsComponent(Content content, Fraction occupancy/
 			}
 		}
 
-		private int getMaxAllowed(ItemStack stack) {
+		private int getMaxAllowed(Fraction itemOccupancy) {
 			Fraction fraction = Fraction.ONE.subtract(this.occupancy);
-			return Math.max(fraction.divideBy(CustomBundleContentsComponent.getOccupancy(stack, this.size_multiplier)).intValue(), 0);
+			return Math.max(fraction.divideBy(itemOccupancy).intValue(), 0);
 		}
 
 		public int add(ItemStack stack) {
 			if (!stack.isEmpty() && stack.getItem().canFitInsideContainerItems()) {
-				int i = Math.min(stack.getCount(), this.getMaxAllowed(stack));
+				DataResult<Fraction> maybeOccupancy = CustomBundleContentsComponent.getOccupancy(stack, this.size_multiplier);
+				if (maybeOccupancy.isError()) {
+					return 0;
+				}
+				Fraction itemOccupancy = maybeOccupancy.getOrThrow();
+				int i = Math.min(stack.getCount(), this.getMaxAllowed(itemOccupancy));
 				if (i == 0) {
 					return 0;
 				} else {
-					this.occupancy = this.occupancy.add(CustomBundleContentsComponent.getOccupancy(stack, this.size_multiplier).multiplyBy(Fraction.getFraction(i, 1)));
+					this.occupancy = this.occupancy.add(itemOccupancy.multiplyBy(Fraction.getFraction(i, 1)));
 					int j = this.addInternal(stack);
 					if (j != -1) {
-						ItemStack itemStack = (ItemStack) this.content.stacks.remove(j);
+						// Unlike vanilla, stacks are never grown past their max stack size (templates cap the count at 99).
+						ItemStack itemStack = this.stacks.remove(j);
 						int maxCount = itemStack.getMaxStackSize();
 						int count = itemStack.getCount();
 						int countDiff = maxCount - count;
 						if (i <= countDiff) {
 							ItemStack itemStack2 = itemStack.copyWithCount(itemStack.getCount() + i);
 							stack.shrink(i);
-							this.content.stacks.add(0, itemStack2);
+							this.stacks.add(0, itemStack2);
 						} else {
 							ItemStack itemStack2 = itemStack.copyWithCount(itemStack.getCount() + countDiff);
-							this.content.stacks.add(0, itemStack2);
+							this.stacks.add(0, itemStack2);
 
 							ItemStack itemStack3 = stack.copyWithCount(i - countDiff);
-							this.content.stacks.add(0, itemStack3);
+							this.stacks.add(0, itemStack3);
 							stack.shrink(i);
 						}
 					} else {
-						this.content.stacks.add(0, stack.split(i));
+						this.stacks.add(0, stack.split(i));
 					}
 
 					return i;
@@ -197,17 +258,20 @@ public record CustomBundleContentsComponent(Content content, Fraction occupancy/
 
 		public int add(Slot slot, Player player) {
 			ItemStack itemStack = slot.getItem();
-			int i = this.getMaxAllowed(itemStack);
+			DataResult<Fraction> itemOccupancy = CustomBundleContentsComponent.getOccupancy(itemStack, this.size_multiplier);
+			if (itemOccupancy.isError()) {
+				return 0;
+			}
+			int i = this.getMaxAllowed(itemOccupancy.getOrThrow());
 			return this.add(slot.safeTake(itemStack.getCount(), i, player));
 		}
 
-		@Nullable
-		public ItemStack removeFirst() {
-			if (this.content.stacks.isEmpty()) {
+		public @Nullable ItemStack removeFirst() {
+			if (this.stacks.isEmpty()) {
 				return null;
 			} else {
-				ItemStack itemStack = ((ItemStack) this.content.stacks.remove(0)).copy();
-				this.occupancy = this.occupancy.subtract(CustomBundleContentsComponent.getOccupancy(itemStack, this.size_multiplier).multiplyBy(Fraction.getFraction(itemStack.getCount(), 1)));
+				ItemStack itemStack = this.stacks.remove(0).copy();
+				this.occupancy = this.occupancy.subtract(CustomBundleContentsComponent.getOccupancy(itemStack, this.size_multiplier).getOrThrow().multiplyBy(Fraction.getFraction(itemStack.getCount(), 1)));
 				return itemStack;
 			}
 		}
@@ -228,19 +292,28 @@ public record CustomBundleContentsComponent(Content content, Fraction occupancy/
 //		}
 
 		public CustomBundleContentsComponent build() {
-			return new CustomBundleContentsComponent(List.copyOf(this.content.stacks), this.occupancy/*, this.tag*/, this.size_multiplier);
+			ImmutableList.Builder<ItemStackTemplate> builder = ImmutableList.builder();
+			for (ItemStack stack : this.stacks) {
+				if (!stack.isEmpty()) {
+					builder.add(ItemStackTemplate.fromNonEmptyStack(stack));
+				}
+			}
+			return new CustomBundleContentsComponent(new Content(builder.build()), this.occupancy/*, this.tag*/, this.size_multiplier);
 		}
 	}
 
-	public record Content(List<ItemStack> stacks) {
+	/**
+	 * @param items the stored item templates, most recently inserted first (immutable)
+	 */
+	public record Content(List<ItemStackTemplate> items) {
 		public static final Content DEFAULT = new Content(List.of());
-		public static final Codec<Content> CODEC = ItemStack.CODEC.listOf().xmap(Content::new, component -> component.stacks);
-		public static final StreamCodec<RegistryFriendlyByteBuf, Content> PACKET_CODEC = ItemStack.STREAM_CODEC
+		public static final Codec<Content> CODEC = ItemStackTemplate.CODEC.listOf().xmap(Content::new, content -> content.items);
+		public static final StreamCodec<RegistryFriendlyByteBuf, Content> PACKET_CODEC = ItemStackTemplate.STREAM_CODEC
 				.apply(ByteBufCodecs.list())
-				.map(Content::new, content -> content.stacks);
+				.map(Content::new, content -> content.items);
 
-		public Content(List<ItemStack> stacks) {
-			this.stacks = new ArrayList<ItemStack>(stacks);
+		public Content(List<ItemStackTemplate> items) {
+			this.items = List.copyOf(items);
 		}
 	}
 }

--- a/common/src/main/java/com/github/theredbrain/bundleapi/component/type/CustomBundleContentsComponent.java
+++ b/common/src/main/java/com/github/theredbrain/bundleapi/component/type/CustomBundleContentsComponent.java
@@ -4,24 +4,24 @@ import com.github.theredbrain.bundleapi.BundleAPI;
 import com.google.common.collect.Lists;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
-import net.minecraft.block.entity.BeehiveBlockEntity;
-import net.minecraft.component.DataComponentTypes;
-import net.minecraft.component.type.BeesComponent;
-import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.item.ItemStack;
-import net.minecraft.item.tooltip.TooltipData;
-import net.minecraft.network.RegistryByteBuf;
-import net.minecraft.network.codec.PacketCodec;
-import net.minecraft.network.codec.PacketCodecs;
-import net.minecraft.screen.slot.Slot;
 import org.apache.commons.lang3.math.Fraction;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.inventory.tooltip.TooltipComponent;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.component.Bees;
+import net.minecraft.world.level.block.entity.BeehiveBlockEntity;
 
-public record CustomBundleContentsComponent(Content content, Fraction occupancy/*, Optional<RegistryEntryList<Item>> tag  TODO add tag key in 1.21.4*/, int size_multiplier) implements TooltipData {
+public record CustomBundleContentsComponent(Content content, Fraction occupancy/*, Optional<RegistryEntryList<Item>> tag  TODO add tag key in 1.21.4*/, int size_multiplier) implements TooltipComponent {
 	public static final CustomBundleContentsComponent DEFAULT = new CustomBundleContentsComponent(List.of()/*, Optional.empty()*/, 1);
 	public static final Codec<CustomBundleContentsComponent> CODEC = RecordCodecBuilder.create(
 			instance -> instance.group(
@@ -31,12 +31,12 @@ public record CustomBundleContentsComponent(Content content, Fraction occupancy/
 					)
 					.apply(instance, CustomBundleContentsComponent::new)
 	);
-	public static final PacketCodec<RegistryByteBuf, CustomBundleContentsComponent> PACKET_CODEC = PacketCodec.tuple(
+	public static final StreamCodec<RegistryFriendlyByteBuf, CustomBundleContentsComponent> PACKET_CODEC = StreamCodec.composite(
 			CustomBundleContentsComponent.Content.PACKET_CODEC,
 			component -> component.content,
 //			PacketCodecs.optional(PacketCodecs.registryEntryList(RegistryKeys.ITEM)),
 //			component -> component.tag,
-			PacketCodecs.VAR_INT,
+			ByteBufCodecs.VAR_INT,
 			component -> component.size_multiplier,
 			CustomBundleContentsComponent::new
 	);
@@ -84,8 +84,8 @@ public record CustomBundleContentsComponent(Content content, Fraction occupancy/
 		if (customBundleContentsComponent != null) {
 			return NESTED_BUNDLE_OCCUPANCY.add(customBundleContentsComponent.getOccupancy());
 		} else {
-			List<BeehiveBlockEntity.BeeData> list = stack.getOrDefault(DataComponentTypes.BEES, BeesComponent.DEFAULT).bees();
-			return !list.isEmpty() ? Fraction.ONE : Fraction.getFraction(1, stack.getMaxCount() * size_multiplier);
+			List<BeehiveBlockEntity.Occupant> list = stack.getOrDefault(DataComponents.BEES, Bees.EMPTY).bees();
+			return !list.isEmpty() ? Fraction.ONE : Fraction.getFraction(1, stack.getMaxStackSize() * size_multiplier);
 		}
 	}
 
@@ -145,7 +145,7 @@ public record CustomBundleContentsComponent(Content content, Fraction occupancy/
 				return -1;
 			} else {
 				for (int i = 0; i < this.content.stacks.size(); i++) {
-					if (ItemStack.areItemsAndComponentsEqual((ItemStack) this.content.stacks.get(i), stack) && this.content.stacks.get(i).getCount() < this.content.stacks.get(i).getMaxCount()) {
+					if (ItemStack.isSameItemSameComponents((ItemStack) this.content.stacks.get(i), stack) && this.content.stacks.get(i).getCount() < this.content.stacks.get(i).getMaxStackSize()) {
 						return i;
 					}
 				}
@@ -160,7 +160,7 @@ public record CustomBundleContentsComponent(Content content, Fraction occupancy/
 		}
 
 		public int add(ItemStack stack) {
-			if (!stack.isEmpty() && stack.getItem().canBeNested()) {
+			if (!stack.isEmpty() && stack.getItem().canFitInsideContainerItems()) {
 				int i = Math.min(stack.getCount(), this.getMaxAllowed(stack));
 				if (i == 0) {
 					return 0;
@@ -169,12 +169,12 @@ public record CustomBundleContentsComponent(Content content, Fraction occupancy/
 					int j = this.addInternal(stack);
 					if (j != -1) {
 						ItemStack itemStack = (ItemStack) this.content.stacks.remove(j);
-						int maxCount = itemStack.getMaxCount();
+						int maxCount = itemStack.getMaxStackSize();
 						int count = itemStack.getCount();
 						int countDiff = maxCount - count;
 						if (i <= countDiff) {
 							ItemStack itemStack2 = itemStack.copyWithCount(itemStack.getCount() + i);
-							stack.decrement(i);
+							stack.shrink(i);
 							this.content.stacks.add(0, itemStack2);
 						} else {
 							ItemStack itemStack2 = itemStack.copyWithCount(itemStack.getCount() + countDiff);
@@ -182,7 +182,7 @@ public record CustomBundleContentsComponent(Content content, Fraction occupancy/
 
 							ItemStack itemStack3 = stack.copyWithCount(i - countDiff);
 							this.content.stacks.add(0, itemStack3);
-							stack.decrement(i);
+							stack.shrink(i);
 						}
 					} else {
 						this.content.stacks.add(0, stack.split(i));
@@ -195,10 +195,10 @@ public record CustomBundleContentsComponent(Content content, Fraction occupancy/
 			}
 		}
 
-		public int add(Slot slot, PlayerEntity player) {
-			ItemStack itemStack = slot.getStack();
+		public int add(Slot slot, Player player) {
+			ItemStack itemStack = slot.getItem();
 			int i = this.getMaxAllowed(itemStack);
-			return this.add(slot.takeStackRange(itemStack.getCount(), i, player));
+			return this.add(slot.safeTake(itemStack.getCount(), i, player));
 		}
 
 		@Nullable
@@ -235,9 +235,9 @@ public record CustomBundleContentsComponent(Content content, Fraction occupancy/
 	public record Content(List<ItemStack> stacks) {
 		public static final Content DEFAULT = new Content(List.of());
 		public static final Codec<Content> CODEC = ItemStack.CODEC.listOf().xmap(Content::new, component -> component.stacks);
-		public static final PacketCodec<RegistryByteBuf, Content> PACKET_CODEC = ItemStack.PACKET_CODEC
-				.collect(PacketCodecs.toList())
-				.xmap(Content::new, content -> content.stacks);
+		public static final StreamCodec<RegistryFriendlyByteBuf, Content> PACKET_CODEC = ItemStack.STREAM_CODEC
+				.apply(ByteBufCodecs.list())
+				.map(Content::new, content -> content.stacks);
 
 		public Content(List<ItemStack> stacks) {
 			this.stacks = new ArrayList<ItemStack>(stacks);

--- a/common/src/main/java/com/github/theredbrain/bundleapi/item/CustomBundleItem.java
+++ b/common/src/main/java/com/github/theredbrain/bundleapi/item/CustomBundleItem.java
@@ -3,37 +3,37 @@ package com.github.theredbrain.bundleapi.item;
 import com.github.theredbrain.bundleapi.BundleAPI;
 import com.github.theredbrain.bundleapi.component.type.CustomBundleContentsComponent;
 import com.github.theredbrain.bundleapi.item.tooltip.CustomBundleTooltipData;
-import net.minecraft.component.DataComponentTypes;
-import net.minecraft.component.type.TooltipDisplayComponent;
-import net.minecraft.entity.Entity;
-import net.minecraft.entity.ItemEntity;
-import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.inventory.StackReference;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemStack;
-import net.minecraft.item.ItemUsage;
-import net.minecraft.item.tooltip.TooltipData;
-import net.minecraft.registry.tag.TagKey;
-import net.minecraft.screen.slot.Slot;
-import net.minecraft.server.network.ServerPlayerEntity;
-import net.minecraft.sound.SoundEvents;
-import net.minecraft.stat.Stats;
-import net.minecraft.text.Text;
-import net.minecraft.util.ClickType;
-import net.minecraft.util.ActionResult;
-import net.minecraft.util.Hand;
-import net.minecraft.util.math.ColorHelper;
-import net.minecraft.util.math.MathHelper;
-import net.minecraft.world.World;
 import org.apache.commons.lang3.math.Fraction;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.sounds.SoundEvents;
+import net.minecraft.stats.Stats;
+import net.minecraft.tags.TagKey;
+import net.minecraft.util.ARGB;
+import net.minecraft.util.Mth;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.SlotAccess;
+import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.ClickAction;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.inventory.tooltip.TooltipComponent;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.ItemUtils;
+import net.minecraft.world.item.component.TooltipDisplay;
+import net.minecraft.world.level.Level;
 
 public class CustomBundleItem extends Item {
-	private static final int ITEM_BAR_COLOR = ColorHelper.fromFloats(1.0F, 0.4F, 0.4F, 1.0F);
+	private static final int ITEM_BAR_COLOR = ARGB.colorFromFloat(1.0F, 0.4F, 0.4F, 1.0F);
 	/**
 	 * @deprecated Kept for binary compatibility. Since 1.21.4 item model properties are data-driven
 	 * (see {@code bundleapi:custom_bundle/fullness}), so BundleAPI no longer iterates the instances
@@ -42,32 +42,32 @@ public class CustomBundleItem extends Item {
 	@Deprecated
 	public final static HashSet<CustomBundleItem> instances = new HashSet<>();
 	private final TagKey<Item> tag;
-	private final Text emptyDescription;
+	private final Component emptyDescription;
 
 	/**
 	 * @param tag              items allowed inside, {@code null} to allow anything nestable
 	 * @param emptyDescription hint shown inside the tooltip while the bundle is empty,
 	 *                         {@code null} for vanilla's "Can hold a mixed stack of items"
 	 */
-	public CustomBundleItem(@Nullable TagKey<Item> tag, @Nullable Text emptyDescription, Settings settings) {
+	public CustomBundleItem(@Nullable TagKey<Item> tag, @Nullable Component emptyDescription, Properties settings) {
 		super(settings);
 		this.tag = tag;
 		this.emptyDescription = emptyDescription != null ? emptyDescription : CustomBundleTooltipData.DEFAULT_EMPTY_DESCRIPTION;
 		instances.add(this);
 	}
 
-	public CustomBundleItem(@Nullable TagKey<Item> tag, Settings settings) {
+	public CustomBundleItem(@Nullable TagKey<Item> tag, Properties settings) {
 		this(tag, null, settings);
 	}
 
-	public CustomBundleItem(Settings settings) {
+	public CustomBundleItem(Properties settings) {
 		this(null, null, settings);
 	}
 
 	/**
 	 * Hint drawn inside the tooltip while this bundle is empty. Never {@code null}.
 	 */
-	public Text getEmptyDescription() {
+	public Component getEmptyDescription() {
 		return this.emptyDescription;
 	}
 
@@ -77,24 +77,24 @@ public class CustomBundleItem extends Item {
 	}
 
 	@Override
-	public boolean onStackClicked(ItemStack stack, Slot slot, ClickType clickType, PlayerEntity player) {
-		if (clickType != ClickType.RIGHT) {
+	public boolean overrideStackedOnOther(ItemStack stack, Slot slot, ClickAction clickType, Player player) {
+		if (clickType != ClickAction.SECONDARY) {
 			return false;
 		} else {
 			CustomBundleContentsComponent customBundleContentsComponent = stack.get(BundleAPI.CUSTOM_BUNDLE_CONTENTS_COMPONENT);
 			if (customBundleContentsComponent == null) {
 				return false;
 			} else {
-				ItemStack itemStack = slot.getStack();
+				ItemStack itemStack = slot.getItem();
 				CustomBundleContentsComponent.Builder builder = new CustomBundleContentsComponent.Builder(customBundleContentsComponent);
 				if (itemStack.isEmpty()) {
 					this.playRemoveOneSound(player);
 					ItemStack itemStack2 = builder.removeFirst();
 					if (itemStack2 != null) {
-						ItemStack itemStack3 = slot.insertStack(itemStack2);
+						ItemStack itemStack3 = slot.safeInsert(itemStack2);
 						builder.add(itemStack3);
 					}
-				} else if (itemStack.getItem().canBeNested() && (this.tag == null || itemStack.isIn(this.tag))) {
+				} else if (itemStack.getItem().canFitInsideContainerItems() && (this.tag == null || itemStack.is(this.tag))) {
 					int i = builder.add(slot, player);
 					if (i > 0) {
 						this.playInsertSound(player);
@@ -108,8 +108,8 @@ public class CustomBundleItem extends Item {
 	}
 
 	@Override
-	public boolean onClicked(ItemStack stack, ItemStack otherStack, Slot slot, ClickType clickType, PlayerEntity player, StackReference cursorStackReference) {
-		if (clickType == ClickType.RIGHT && slot.canTakePartial(player)) {
+	public boolean overrideOtherStackedOnMe(ItemStack stack, ItemStack otherStack, Slot slot, ClickAction clickType, Player player, SlotAccess cursorStackReference) {
+		if (clickType == ClickAction.SECONDARY && slot.allowModification(player)) {
 			CustomBundleContentsComponent customBundleContentsComponent = stack.get(BundleAPI.CUSTOM_BUNDLE_CONTENTS_COMPONENT);
 			if (customBundleContentsComponent == null) {
 				return false;
@@ -121,7 +121,7 @@ public class CustomBundleItem extends Item {
 						this.playRemoveOneSound(player);
 						cursorStackReference.set(itemStack);
 					}
-				} else if (this.tag == null || otherStack.isIn(this.tag)) {
+				} else if (this.tag == null || otherStack.is(this.tag)) {
 					int i = builder.add(otherStack);
 					if (i > 0) {
 						this.playInsertSound(player);
@@ -137,40 +137,40 @@ public class CustomBundleItem extends Item {
 	}
 
 	@Override
-	public ActionResult use(World world, PlayerEntity user, Hand hand) {
-		ItemStack itemStack = user.getStackInHand(hand);
+	public InteractionResult use(Level world, Player user, InteractionHand hand) {
+		ItemStack itemStack = user.getItemInHand(hand);
 		if (dropAllBundledItems(itemStack, user)) {
 			this.playDropContentsSound(user);
-			user.incrementStat(Stats.USED.getOrCreateStat(this));
-			return world.isClient() ? ActionResult.SUCCESS : ActionResult.SUCCESS_SERVER;
+			user.awardStat(Stats.ITEM_USED.get(this));
+			return world.isClientSide() ? InteractionResult.SUCCESS : InteractionResult.SUCCESS_SERVER;
 		} else {
-			return ActionResult.FAIL;
+			return InteractionResult.FAIL;
 		}
 	}
 
 	@Override
-	public boolean isItemBarVisible(ItemStack stack) {
+	public boolean isBarVisible(ItemStack stack) {
 		CustomBundleContentsComponent customBundleContentsComponent = stack.getOrDefault(BundleAPI.CUSTOM_BUNDLE_CONTENTS_COMPONENT, CustomBundleContentsComponent.DEFAULT);
 		return customBundleContentsComponent.getOccupancy().compareTo(Fraction.ZERO) > 0;
 	}
 
 	@Override
-	public int getItemBarStep(ItemStack stack) {
+	public int getBarWidth(ItemStack stack) {
 		CustomBundleContentsComponent customBundleContentsComponent = stack.getOrDefault(BundleAPI.CUSTOM_BUNDLE_CONTENTS_COMPONENT, CustomBundleContentsComponent.DEFAULT);
-		return Math.min(1 + MathHelper.multiplyFraction(customBundleContentsComponent.getOccupancy(), 12), 13);
+		return Math.min(1 + Mth.mulAndTruncate(customBundleContentsComponent.getOccupancy(), 12), 13);
 	}
 
 	@Override
-	public int getItemBarColor(ItemStack stack) {
+	public int getBarColor(ItemStack stack) {
 		return ITEM_BAR_COLOR;
 	}
 
-	private static boolean dropAllBundledItems(ItemStack stack, PlayerEntity player) {
+	private static boolean dropAllBundledItems(ItemStack stack, Player player) {
 		CustomBundleContentsComponent customBundleContentsComponent = stack.get(BundleAPI.CUSTOM_BUNDLE_CONTENTS_COMPONENT);
 		if (customBundleContentsComponent != null && !customBundleContentsComponent.isEmpty()) {
 			stack.set(BundleAPI.CUSTOM_BUNDLE_CONTENTS_COMPONENT, new CustomBundleContentsComponent.Builder(customBundleContentsComponent).clear().build());
-			if (player instanceof ServerPlayerEntity) {
-				customBundleContentsComponent.iterateCopy().forEach(stackx -> player.dropItem(stackx, true));
+			if (player instanceof ServerPlayer) {
+				customBundleContentsComponent.iterateCopy().forEach(stackx -> player.drop(stackx, true));
 			}
 
 			return true;
@@ -180,31 +180,31 @@ public class CustomBundleItem extends Item {
 	}
 
 	@Override
-	public Optional<TooltipData> getTooltipData(ItemStack stack) {
-		TooltipDisplayComponent tooltipDisplayComponent = stack.getOrDefault(DataComponentTypes.TOOLTIP_DISPLAY, TooltipDisplayComponent.DEFAULT);
-		return !tooltipDisplayComponent.shouldDisplay(BundleAPI.CUSTOM_BUNDLE_CONTENTS_COMPONENT)
+	public Optional<TooltipComponent> getTooltipImage(ItemStack stack) {
+		TooltipDisplay tooltipDisplayComponent = stack.getOrDefault(DataComponents.TOOLTIP_DISPLAY, TooltipDisplay.DEFAULT);
+		return !tooltipDisplayComponent.shows(BundleAPI.CUSTOM_BUNDLE_CONTENTS_COMPONENT)
 			? Optional.empty()
 			: Optional.ofNullable(stack.get(BundleAPI.CUSTOM_BUNDLE_CONTENTS_COMPONENT)).map(contents -> new CustomBundleTooltipData(contents, this.emptyDescription));
 	}
 
 	@Override
-	public void onItemEntityDestroyed(ItemEntity entity) {
-		CustomBundleContentsComponent customBundleContentsComponent = entity.getStack().get(BundleAPI.CUSTOM_BUNDLE_CONTENTS_COMPONENT);
+	public void onDestroyed(ItemEntity entity) {
+		CustomBundleContentsComponent customBundleContentsComponent = entity.getItem().get(BundleAPI.CUSTOM_BUNDLE_CONTENTS_COMPONENT);
 		if (customBundleContentsComponent != null) {
-			entity.getStack().set(BundleAPI.CUSTOM_BUNDLE_CONTENTS_COMPONENT, new CustomBundleContentsComponent.Builder(customBundleContentsComponent).clear().build());
-			ItemUsage.spawnItemContents(entity, customBundleContentsComponent.iterateCopy());
+			entity.getItem().set(BundleAPI.CUSTOM_BUNDLE_CONTENTS_COMPONENT, new CustomBundleContentsComponent.Builder(customBundleContentsComponent).clear().build());
+			ItemUtils.onContainerDestroyed(entity, customBundleContentsComponent.iterateCopy());
 		}
 	}
 
 	private void playRemoveOneSound(Entity entity) {
-		entity.playSound(SoundEvents.ITEM_BUNDLE_REMOVE_ONE, 0.8F, 0.8F + entity.getEntityWorld().getRandom().nextFloat() * 0.4F);
+		entity.playSound(SoundEvents.BUNDLE_REMOVE_ONE, 0.8F, 0.8F + entity.level().getRandom().nextFloat() * 0.4F);
 	}
 
 	private void playInsertSound(Entity entity) {
-		entity.playSound(SoundEvents.ITEM_BUNDLE_INSERT, 0.8F, 0.8F + entity.getEntityWorld().getRandom().nextFloat() * 0.4F);
+		entity.playSound(SoundEvents.BUNDLE_INSERT, 0.8F, 0.8F + entity.level().getRandom().nextFloat() * 0.4F);
 	}
 
 	private void playDropContentsSound(Entity entity) {
-		entity.playSound(SoundEvents.ITEM_BUNDLE_DROP_CONTENTS, 0.8F, 0.8F + entity.getEntityWorld().getRandom().nextFloat() * 0.4F);
+		entity.playSound(SoundEvents.BUNDLE_DROP_CONTENTS, 0.8F, 0.8F + entity.level().getRandom().nextFloat() * 0.4F);
 	}
 }

--- a/common/src/main/java/com/github/theredbrain/bundleapi/item/CustomBundleItem.java
+++ b/common/src/main/java/com/github/theredbrain/bundleapi/item/CustomBundleItem.java
@@ -4,7 +4,7 @@ import com.github.theredbrain.bundleapi.BundleAPI;
 import com.github.theredbrain.bundleapi.component.type.CustomBundleContentsComponent;
 import com.github.theredbrain.bundleapi.item.tooltip.CustomBundleTooltipData;
 import org.apache.commons.lang3.math.Fraction;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import java.util.HashSet;
 import java.util.List;
@@ -170,7 +170,7 @@ public class CustomBundleItem extends Item {
 		if (customBundleContentsComponent != null && !customBundleContentsComponent.isEmpty()) {
 			stack.set(BundleAPI.CUSTOM_BUNDLE_CONTENTS_COMPONENT, new CustomBundleContentsComponent.Builder(customBundleContentsComponent).clear().build());
 			if (player instanceof ServerPlayer) {
-				customBundleContentsComponent.iterateCopy().forEach(stackx -> player.drop(stackx, true));
+				customBundleContentsComponent.stream().forEach(stackx -> player.drop(stackx, true));
 			}
 
 			return true;
@@ -192,7 +192,7 @@ public class CustomBundleItem extends Item {
 		CustomBundleContentsComponent customBundleContentsComponent = entity.getItem().get(BundleAPI.CUSTOM_BUNDLE_CONTENTS_COMPONENT);
 		if (customBundleContentsComponent != null) {
 			entity.getItem().set(BundleAPI.CUSTOM_BUNDLE_CONTENTS_COMPONENT, new CustomBundleContentsComponent.Builder(customBundleContentsComponent).clear().build());
-			ItemUtils.onContainerDestroyed(entity, customBundleContentsComponent.iterateCopy());
+			ItemUtils.onContainerDestroyed(entity, customBundleContentsComponent.stream());
 		}
 	}
 

--- a/common/src/main/java/com/github/theredbrain/bundleapi/item/tooltip/CustomBundleTooltipData.java
+++ b/common/src/main/java/com/github/theredbrain/bundleapi/item/tooltip/CustomBundleTooltipData.java
@@ -1,19 +1,19 @@
 package com.github.theredbrain.bundleapi.item.tooltip;
 
 import com.github.theredbrain.bundleapi.component.type.CustomBundleContentsComponent;
-import net.minecraft.item.tooltip.TooltipData;
-import net.minecraft.text.Text;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.inventory.tooltip.TooltipComponent;
 
 /**
  * @param contents         the bundle's contents
  * @param emptyDescription the hint text drawn inside the tooltip while the bundle is empty
  *                         (vanilla's "Can hold a mixed stack of items" by default)
  */
-public record CustomBundleTooltipData(CustomBundleContentsComponent contents, Text emptyDescription) implements TooltipData {
+public record CustomBundleTooltipData(CustomBundleContentsComponent contents, Component emptyDescription) implements TooltipComponent {
 	/**
 	 * Vanilla's empty-bundle hint, used by every bundle that does not provide its own.
 	 */
-	public static final Text DEFAULT_EMPTY_DESCRIPTION = Text.translatable("item.minecraft.bundle.empty.description");
+	public static final Component DEFAULT_EMPTY_DESCRIPTION = Component.translatable("item.minecraft.bundle.empty.description");
 
 	/**
 	 * @deprecated Kept for binary compatibility, uses {@link #DEFAULT_EMPTY_DESCRIPTION}.

--- a/common/src/main/java/com/github/theredbrain/bundleapi/mixin/client/NumericPropertiesMixin.java
+++ b/common/src/main/java/com/github/theredbrain/bundleapi/mixin/client/NumericPropertiesMixin.java
@@ -3,10 +3,10 @@ package com.github.theredbrain.bundleapi.mixin.client;
 import com.github.theredbrain.bundleapi.BundleAPI;
 import com.github.theredbrain.bundleapi.client.render.item.property.numeric.CustomBundleFullnessProperty;
 import com.mojang.serialization.MapCodec;
-import net.minecraft.client.render.item.property.numeric.NumericProperties;
-import net.minecraft.client.render.item.property.numeric.NumericProperty;
-import net.minecraft.util.Identifier;
-import net.minecraft.util.dynamic.Codecs;
+import net.minecraft.client.renderer.item.properties.numeric.RangeSelectItemModelProperties;
+import net.minecraft.client.renderer.item.properties.numeric.RangeSelectItemModelProperty;
+import net.minecraft.resources.Identifier;
+import net.minecraft.util.ExtraCodecs;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -18,11 +18,11 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
  * Registers BundleAPI's item model numeric properties. {@code NumericProperties} has no public
  * registration hook, so the id mapper is shadowed and appended to during vanilla's bootstrap.
  */
-@Mixin(NumericProperties.class)
+@Mixin(RangeSelectItemModelProperties.class)
 public class NumericPropertiesMixin {
     @Shadow
     @Final
-    private static Codecs.IdMapper<Identifier, MapCodec<? extends NumericProperty>> ID_MAPPER;
+    private static ExtraCodecs.LateBoundIdMapper<Identifier, MapCodec<? extends RangeSelectItemModelProperty>> ID_MAPPER;
 
     @Inject(method = "bootstrap", at = @At("TAIL"))
     private static void bundleapi$bootstrap(CallbackInfo ci) {

--- a/common/src/main/java/com/github/theredbrain/bundleapi/mixin/client/gui/tooltip/TooltipComponentMixin.java
+++ b/common/src/main/java/com/github/theredbrain/bundleapi/mixin/client/gui/tooltip/TooltipComponentMixin.java
@@ -2,22 +2,22 @@ package com.github.theredbrain.bundleapi.mixin.client.gui.tooltip;
 
 import com.github.theredbrain.bundleapi.client.gui.tooltip.CustomBundleTooltipComponent;
 import com.github.theredbrain.bundleapi.item.tooltip.CustomBundleTooltipData;
-import net.minecraft.client.gui.tooltip.TooltipComponent;
-import net.minecraft.item.tooltip.TooltipData;
+import net.minecraft.client.gui.screens.inventory.tooltip.ClientTooltipComponent;
+import net.minecraft.world.inventory.tooltip.TooltipComponent;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-@Mixin(TooltipComponent.class)
+@Mixin(ClientTooltipComponent.class)
 public interface TooltipComponentMixin {
 
 	@Inject(
-			method = "of(Lnet/minecraft/item/tooltip/TooltipData;)Lnet/minecraft/client/gui/tooltip/TooltipComponent;",
+			method = "create(Lnet/minecraft/world/inventory/tooltip/TooltipComponent;)Lnet/minecraft/client/gui/screens/inventory/tooltip/ClientTooltipComponent;",
 			at = @At("HEAD"),
 			cancellable = true
 	)
-	private static void of(TooltipData data, CallbackInfoReturnable<TooltipComponent> cir) {
+	private static void of(TooltipComponent data, CallbackInfoReturnable<ClientTooltipComponent> cir) {
 		if (data instanceof CustomBundleTooltipData customBundleTooltipData) {
 			cir.setReturnValue(new CustomBundleTooltipComponent(customBundleTooltipData.contents(), customBundleTooltipData.emptyDescription()));
 			cir.cancel();

--- a/common/src/main/java/com/github/theredbrain/bundleapi/mixin/registry/ComponentPredicateTypesMixin.java
+++ b/common/src/main/java/com/github/theredbrain/bundleapi/mixin/registry/ComponentPredicateTypesMixin.java
@@ -1,21 +1,21 @@
 package com.github.theredbrain.bundleapi.mixin.registry;
 
 import com.github.theredbrain.bundleapi.BundleAPI;
-import net.minecraft.predicate.component.ComponentPredicateTypes;
-import net.minecraft.registry.Registries;
-import net.minecraft.registry.Registry;
+import net.minecraft.core.Registry;
+import net.minecraft.core.component.predicates.DataComponentPredicates;
+import net.minecraft.core.registries.BuiltInRegistries;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@Mixin(ComponentPredicateTypes.class)
+@Mixin(DataComponentPredicates.class)
 public class ComponentPredicateTypesMixin {
     // Static class init tail inject
     @Inject(method = "<clinit>", at = @At("TAIL"))
     private static void static_init_TAIL_BundleAPI(CallbackInfo ci) {
         Registry.register(
-                Registries.DATA_COMPONENT_PREDICATE_TYPE,
+                BuiltInRegistries.DATA_COMPONENT_PREDICATE_TYPE,
                 BundleAPI.identifier("custom_bundle_contents"),
                 BundleAPI.CUSTOM_BUNDLE_CONTENTS_ITEM_SUB_PREDICATE
         );

--- a/common/src/main/java/com/github/theredbrain/bundleapi/mixin/registry/DataComponentTypesMixin.java
+++ b/common/src/main/java/com/github/theredbrain/bundleapi/mixin/registry/DataComponentTypesMixin.java
@@ -1,21 +1,21 @@
 package com.github.theredbrain.bundleapi.mixin.registry;
 
 import com.github.theredbrain.bundleapi.BundleAPI;
-import net.minecraft.component.DataComponentTypes;
-import net.minecraft.registry.Registries;
-import net.minecraft.registry.Registry;
+import net.minecraft.core.Registry;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.core.registries.BuiltInRegistries;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@Mixin(DataComponentTypes.class)
+@Mixin(DataComponents.class)
 public class DataComponentTypesMixin {
     // Static class init tail inject
     @Inject(method = "<clinit>", at = @At("TAIL"))
     private static void static_init_TAIL_BundleAPI(CallbackInfo ci) {
         Registry.register(
-                Registries.DATA_COMPONENT_TYPE,
+                BuiltInRegistries.DATA_COMPONENT_TYPE,
                 BundleAPI.identifier("custom_bundle_contents"),
                 BundleAPI.CUSTOM_BUNDLE_CONTENTS_COMPONENT
         );

--- a/common/src/main/java/com/github/theredbrain/bundleapi/predicate/item/CustomBundleContentsPredicate.java
+++ b/common/src/main/java/com/github/theredbrain/bundleapi/predicate/item/CustomBundleContentsPredicate.java
@@ -4,28 +4,27 @@ import com.github.theredbrain.bundleapi.BundleAPI;
 import com.github.theredbrain.bundleapi.component.type.CustomBundleContentsComponent;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
-import net.minecraft.component.ComponentType;
-import net.minecraft.item.ItemStack;
-import net.minecraft.predicate.collection.CollectionPredicate;
-import net.minecraft.predicate.component.ComponentSubPredicate;
-import net.minecraft.predicate.item.ItemPredicate;
-
 import java.util.Optional;
+import net.minecraft.advancements.criterion.CollectionPredicate;
+import net.minecraft.advancements.criterion.ItemPredicate;
+import net.minecraft.advancements.criterion.SingleComponentItemPredicate;
+import net.minecraft.core.component.DataComponentType;
+import net.minecraft.world.item.ItemStack;
 
 public record CustomBundleContentsPredicate(
-		Optional<CollectionPredicate<ItemStack, ItemPredicate>> items) implements ComponentSubPredicate<CustomBundleContentsComponent> {
+		Optional<CollectionPredicate<ItemStack, ItemPredicate>> items) implements SingleComponentItemPredicate<CustomBundleContentsComponent> {
 	public static final Codec<CustomBundleContentsPredicate> CODEC = RecordCodecBuilder.create(
-			instance -> instance.group(CollectionPredicate.<ItemStack, ItemPredicate>createCodec(ItemPredicate.CODEC).optionalFieldOf("items").forGetter(CustomBundleContentsPredicate::items))
+			instance -> instance.group(CollectionPredicate.<ItemStack, ItemPredicate>codec(ItemPredicate.CODEC).optionalFieldOf("items").forGetter(CustomBundleContentsPredicate::items))
 					.apply(instance, CustomBundleContentsPredicate::new)
 	);
 
 	@Override
-	public ComponentType<CustomBundleContentsComponent> getComponentType() {
+	public DataComponentType<CustomBundleContentsComponent> componentType() {
 		return BundleAPI.CUSTOM_BUNDLE_CONTENTS_COMPONENT;
 	}
 
 	@Override
-	public boolean test(CustomBundleContentsComponent customBundleContentsComponent) {
+	public boolean matches(CustomBundleContentsComponent customBundleContentsComponent) {
 		return !this.items.isPresent() || this.items.get().test(customBundleContentsComponent.iterate());
 	}
 }

--- a/common/src/main/java/com/github/theredbrain/bundleapi/predicate/item/CustomBundleContentsPredicate.java
+++ b/common/src/main/java/com/github/theredbrain/bundleapi/predicate/item/CustomBundleContentsPredicate.java
@@ -9,12 +9,15 @@ import net.minecraft.advancements.criterion.CollectionPredicate;
 import net.minecraft.advancements.criterion.ItemPredicate;
 import net.minecraft.advancements.criterion.SingleComponentItemPredicate;
 import net.minecraft.core.component.DataComponentType;
-import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.ItemInstance;
 
+/**
+ * Mirrors vanilla {@code BundlePredicate}.
+ */
 public record CustomBundleContentsPredicate(
-		Optional<CollectionPredicate<ItemStack, ItemPredicate>> items) implements SingleComponentItemPredicate<CustomBundleContentsComponent> {
+		Optional<CollectionPredicate<ItemInstance, ItemPredicate>> items) implements SingleComponentItemPredicate<CustomBundleContentsComponent> {
 	public static final Codec<CustomBundleContentsPredicate> CODEC = RecordCodecBuilder.create(
-			instance -> instance.group(CollectionPredicate.<ItemStack, ItemPredicate>codec(ItemPredicate.CODEC).optionalFieldOf("items").forGetter(CustomBundleContentsPredicate::items))
+			instance -> instance.group(CollectionPredicate.<ItemInstance, ItemPredicate>codec(ItemPredicate.CODEC).optionalFieldOf("items").forGetter(CustomBundleContentsPredicate::items))
 					.apply(instance, CustomBundleContentsPredicate::new)
 	);
 
@@ -25,6 +28,6 @@ public record CustomBundleContentsPredicate(
 
 	@Override
 	public boolean matches(CustomBundleContentsComponent customBundleContentsComponent) {
-		return !this.items.isPresent() || this.items.get().test(customBundleContentsComponent.iterate());
+		return !this.items.isPresent() || this.items.get().test(customBundleContentsComponent.items());
 	}
 }

--- a/common/src/main/resources/bundleapi.mixins.json
+++ b/common/src/main/resources/bundleapi.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "com.github.theredbrain.bundleapi.mixin",
-  "compatibilityLevel": "JAVA_21",
+  "compatibilityLevel": "JAVA_25",
   "client": [
     "client.NumericPropertiesMixin",
     "client.gui.tooltip.TooltipComponentMixin"

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -61,12 +61,12 @@ repositories {
 }
 
 dependencies {
-    modImplementation "net.fabricmc:fabric-loader:$rootProject.fabric_loader_version"
-    common(project(path: ':common', configuration: 'namedElements')) { transitive = false }
+    implementation "net.fabricmc:fabric-loader:$rootProject.fabric_loader_version"
+    common(project(path: ':common')) { transitive = false }
     shadowBundle project(path: ':common', configuration: 'transformProductionFabric')
 
     // Fabric API, only for the testmod
-    modImplementation "net.fabricmc.fabric-api:fabric-api:$rootProject.fabric_api_version"
+    implementation "net.fabricmc.fabric-api:fabric-api:$rootProject.fabric_api_version"
 }
 
 processResources {
@@ -77,13 +77,28 @@ processResources {
     }
 }
 
-shadowJar {
-    configurations = [project.configurations.shadowBundle]
-    archiveClassifier = 'dev-shadow'
+// Minecraft is not obfuscated on this version, so there is no remapJar task.
+// The shaded jar is the mod jar that ships.
+jar {
+    archiveClassifier = 'dev'
 }
 
-remapJar {
-    inputFile.set shadowJar.archiveFile
+shadowJar {
+    configurations = [project.configurations.shadowBundle]
+    archiveClassifier = null
+}
+
+assemble.dependsOn shadowJar
+
+configurations {
+    apiElements {
+        outgoing.artifacts.clear()
+        outgoing.artifact(shadowJar)
+    }
+    runtimeElements {
+        outgoing.artifacts.clear()
+        outgoing.artifact(shadowJar)
+    }
 }
 
 if (project.hasProperty('release_type')) {
@@ -101,13 +116,12 @@ if (project.hasProperty('release_type')) {
             changelog = changelog_last_section()
             changelogType = 'markdown'
             releaseType = release_type
-            addGameVersion "${project.minecraft_version}"
-            addGameVersion "${project.minecraft_version_compat}"
+            rootProject.minecraftCompatVersions.each { addGameVersion it }
             addGameVersion "Fabric"
 
-            mainArtifact(remapJar)
+            mainArtifact(shadowJar)
             afterEvaluate {
-                uploadTask.dependsOn(remapJar)
+                uploadTask.dependsOn(shadowJar)
             }
             options {
                 forgeGradleIntegration = false
@@ -123,8 +137,8 @@ if (project.hasProperty('release_type')) {
         versionNumber = "${version}-fabric"
         // You don't need to set this manually. Will fail if Modrinth has this version already
         versionType = release_type // This is the default -- can also be `beta` or `alpha`
-        uploadFile = remapJar // With Loom, this MUST be set to `remapJar` instead of `jar`!
-        gameVersions = ["${project.minecraft_version}", "${project.minecraft_version_compat}"] // Must be an array, even with only one version
+        uploadFile = shadowJar // no remapJar on 26.1+: the shaded jar is the shipped artifact
+        gameVersions = rootProject.minecraftCompatVersions // Must be an array, even with only one version
         loaders = ["fabric"] // Must also be an array - no need to specify this if you're using Loom or ForgeGradle
         changelog = changelog_last_section()
         dependencies { // A special DSL for creating dependencies

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -25,8 +25,8 @@
 		"bundleapi.mixins.json"
 	],
 	"depends": {
-		"minecraft": "~${minecraft_version}",
+		"minecraft": ">=${minecraft_min_version}",
 		"fabricloader": ">=${fabric_loader_version}",
-		"java": ">=21"
+		"java": ">=25"
 	}
 }

--- a/fabric/src/testmod/java/com/github/theredbrain/bundleapi_test/BundleAPITest.java
+++ b/fabric/src/testmod/java/com/github/theredbrain/bundleapi_test/BundleAPITest.java
@@ -5,15 +5,15 @@ import com.github.theredbrain.bundleapi.component.type.CustomBundleContentsCompo
 import com.github.theredbrain.bundleapi.item.CustomBundleItem;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.itemgroup.v1.ItemGroupEvents;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemGroup;
-import net.minecraft.item.ItemGroups;
-import net.minecraft.registry.Registries;
-import net.minecraft.registry.Registry;
-import net.minecraft.registry.RegistryKey;
-import net.minecraft.registry.RegistryKeys;
-import net.minecraft.registry.tag.TagKey;
-import net.minecraft.util.Identifier;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.world.item.CreativeModeTabs;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.Registry;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.tags.TagKey;
+import net.minecraft.resources.Identifier;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,40 +29,40 @@ public class BundleAPITest implements ModInitializer {
 		LOGGER.info("Testing Bundle API!");
 	}
 
-	private static Item registerItem(String name, Function<Item.Settings, Item> factory, @Nullable RegistryKey<ItemGroup> itemGroup) {
-		RegistryKey<Item> registryKey = RegistryKey.of(RegistryKeys.ITEM, identifier(name));
-		// Since 1.21.2 every Item.Settings must carry its registry key or item construction crashes.
-		Item item = factory.apply(new Item.Settings().registryKey(registryKey));
+	private static Item registerItem(String name, Function<Item.Properties, Item> factory, @Nullable ResourceKey<CreativeModeTab> itemGroup) {
+		ResourceKey<Item> registryKey = ResourceKey.create(Registries.ITEM, identifier(name));
+		// Since 1.21.2 every Item.Properties must carry its registry key or item construction crashes.
+		Item item = factory.apply(new Item.Properties().setId(registryKey));
 
 		if (itemGroup != null) {
 			ItemGroupEvents.modifyEntriesEvent(itemGroup).register(content -> {
-				content.add(item);
+				content.accept(item);
 			});
 		}
-		return Registry.register(Registries.ITEM, registryKey, item);
+		return Registry.register(BuiltInRegistries.ITEM, registryKey, item);
 	}
 
-	public static final TagKey<Item> TEST_BUNDLE_TAG = TagKey.of(RegistryKeys.ITEM, identifier("test_bundle_tag"));
+	public static final TagKey<Item> TEST_BUNDLE_TAG = TagKey.create(Registries.ITEM, identifier("test_bundle_tag"));
 
 	public static Item TEST_BUNDLE = registerItem(
 			"test_bundle",
 			settings -> new CustomBundleItem(settings
-					.maxCount(1)
+					.stacksTo(1)
 					.component(BundleAPI.CUSTOM_BUNDLE_CONTENTS_COMPONENT, CustomBundleContentsComponent.builder().size_multiplier(2).build())
 			),
-			ItemGroups.OPERATOR
+			CreativeModeTabs.OP_BLOCKS
 	);
 
 	public static Item TEST_QUIVER = registerItem(
 			"test_quiver",
 			settings -> new CustomBundleItem(TEST_BUNDLE_TAG, settings
-					.maxCount(1)
+					.stacksTo(1)
 					.component(BundleAPI.CUSTOM_BUNDLE_CONTENTS_COMPONENT, CustomBundleContentsComponent.builder().size_multiplier(3).build())
 			),
-			ItemGroups.OPERATOR
+			CreativeModeTabs.OP_BLOCKS
 	);
 
 	public static Identifier identifier(String path) {
-		return Identifier.of(MOD_ID, path);
+		return Identifier.fromNamespaceAndPath(MOD_ID, path);
 	}
 }

--- a/fabric/src/testmod/java/com/github/theredbrain/bundleapi_test/BundleAPITest.java
+++ b/fabric/src/testmod/java/com/github/theredbrain/bundleapi_test/BundleAPITest.java
@@ -4,7 +4,7 @@ import com.github.theredbrain.bundleapi.BundleAPI;
 import com.github.theredbrain.bundleapi.component.type.CustomBundleContentsComponent;
 import com.github.theredbrain.bundleapi.item.CustomBundleItem;
 import net.fabricmc.api.ModInitializer;
-import net.fabricmc.fabric.api.itemgroup.v1.ItemGroupEvents;
+import net.fabricmc.fabric.api.creativetab.v1.CreativeModeTabEvents;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.CreativeModeTabs;
@@ -14,7 +14,7 @@ import net.minecraft.resources.ResourceKey;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.tags.TagKey;
 import net.minecraft.resources.Identifier;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,7 +35,7 @@ public class BundleAPITest implements ModInitializer {
 		Item item = factory.apply(new Item.Properties().setId(registryKey));
 
 		if (itemGroup != null) {
-			ItemGroupEvents.modifyEntriesEvent(itemGroup).register(content -> {
+			CreativeModeTabEvents.modifyOutputEvent(itemGroup).register(content -> {
 				content.accept(item);
 			});
 		}

--- a/fabric/src/testmod/resources/fabric.mod.json
+++ b/fabric/src/testmod/resources/fabric.mod.json
@@ -17,5 +17,7 @@
     ]
   },
   "mixins": [],
-  "depends": {}
+  "depends": {
+    "java": ">=25"
+  }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-Xmx2G
 org.gradle.parallel=true
 
 # Mod properties
-mod_version = 1.1.2.001
+mod_version = 1.1.1
 maven_group = com.github.TheRedBrain
 archives_name = bundle-api
 enabled_platforms = fabric,neoforge

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-Xmx2G
 org.gradle.parallel=true
 
 # Mod properties
-mod_version = 1.1.1.004
+mod_version = 1.1.2.001
 maven_group = com.github.TheRedBrain
 archives_name = bundle-api
 enabled_platforms = fabric,neoforge

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-Xmx2G
 org.gradle.parallel=true
 
 # Mod properties
-mod_version = 1.1.1.003
+mod_version = 1.1.1.004
 maven_group = com.github.TheRedBrain
 archives_name = bundle-api
 enabled_platforms = fabric,neoforge
@@ -11,8 +11,6 @@ enabled_platforms = fabric,neoforge
 # Minecraft properties
 minecraft_version = 1.21.11
 minecraft_version_compat = 1.21.11
-yarn_mappings = 1.21.11+build.1
-yarn_mappings_patch_neoforge_version = 1.21+build.6
 
 # Dependencies
 fabric_loader_version = 0.19.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,10 +9,11 @@ archives_name = bundle-api
 enabled_platforms = fabric,neoforge
 
 # Minecraft properties
-minecraft_version = 1.21.11
-minecraft_version_compat = 1.21.11
+minecraft_version = 26.1.2
+# Supported game versions, oldest first (manifest minimum = first entry).
+minecraft_compat_versions = 26.1:26.1.1:26.1.2
 
 # Dependencies
 fabric_loader_version = 0.19.3
-fabric_api_version = 0.141.6+1.21.11
-neoforge_version = 21.11.45
+fabric_api_version = 0.155.2+26.1.2
+neoforge_version = 26.1.2.94

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -46,7 +46,7 @@ repositories {
 dependencies {
     neoForge "net.neoforged:neoforge:$rootProject.neoforge_version"
 
-    common(project(path: ':common', configuration: 'namedElements')) { transitive = false }
+    common(project(path: ':common')) { transitive = false }
     shadowBundle project(path: ':common', configuration: 'transformProductionNeoForge')
 }
 
@@ -63,13 +63,28 @@ processResources {
     }
 }
 
-shadowJar {
-    configurations = [project.configurations.shadowBundle]
-    archiveClassifier = 'dev-shadow'
+// Minecraft is not obfuscated on this version, so there is no remapJar task.
+// The shaded jar is the mod jar that ships.
+jar {
+    archiveClassifier = 'dev'
 }
 
-remapJar {
-    inputFile.set shadowJar.archiveFile
+shadowJar {
+    configurations = [project.configurations.shadowBundle]
+    archiveClassifier = null
+}
+
+assemble.dependsOn shadowJar
+
+configurations {
+    apiElements {
+        outgoing.artifacts.clear()
+        outgoing.artifact(shadowJar)
+    }
+    runtimeElements {
+        outgoing.artifacts.clear()
+        outgoing.artifact(shadowJar)
+    }
 }
 
 if(project.hasProperty('release_type')) {
@@ -86,13 +101,12 @@ if(project.hasProperty('release_type')) {
             changelog = changelog_last_section()
             changelogType = 'markdown'
             releaseType = release_type
-            addGameVersion "${project.minecraft_version}"
-            addGameVersion "${project.minecraft_version_compat}"
+            rootProject.minecraftCompatVersions.each { addGameVersion it }
             addGameVersion "NeoForge"
 
-            mainArtifact(remapJar)
+            mainArtifact(shadowJar)
             afterEvaluate {
-                uploadTask.dependsOn(remapJar)
+                uploadTask.dependsOn(shadowJar)
             }
             options {
                 forgeGradleIntegration = false
@@ -107,8 +121,8 @@ if(project.hasProperty('release_type')) {
         versionName = "${version}" // You don't need to set this manually. Will fail if Modrinth has this version already
         versionNumber = "${version}-neoforge" // You don't need to set this manually. Will fail if Modrinth has this version already
         versionType = release_type // This is the default -- can also be `beta` or `alpha`
-        uploadFile = remapJar // With Loom, this MUST be set to `remapJar` instead of `jar`!
-        gameVersions = ["${project.minecraft_version}", "${project.minecraft_version_compat}"] // Must be an array, even with only one version
+        uploadFile = shadowJar // no remapJar on 26.1+: the shaded jar is the shipped artifact
+        gameVersions = rootProject.minecraftCompatVersions // Must be an array, even with only one version
         loaders = ["neoforge"] // Must also be an array - no need to specify this if you're using Loom or ForgeGradle
         changelog = changelog_last_section()
         dependencies { // A special DSL for creating dependencies

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -16,14 +16,14 @@ logoFile = "icon.png"
 [[dependencies.bundleapi]]
 modId = "neoforge"
 type = "required"
-versionRange = "[21.11,)"
+versionRange = "[${minecraft_min_version},)"
 ordering = "NONE"
 side = "BOTH"
 
 [[dependencies.bundleapi]]
 modId = "minecraft"
 type = "required"
-versionRange = "[1.21.11,)"
+versionRange = "[${minecraft_min_version},)"
 ordering = "NONE"
 side = "BOTH"
 


### PR DESCRIPTION
Port to Minecraft 26.1.2 (mojmap, loom-no-remap, java 25), on top of the 1.21.11 branch.

Notable bits:
- BundleContents stores ItemStackTemplate now, since item stacks can't exist before registries load
- tooltip rendering moved to GuiGraphicsExtractor
- fixed a class-init cycle between DataComponents and the mod init that deadlocked with NeoForge's parallel registry loading

Builds and boots on both loaders, testmod included. Version 1.1.1.