### PR TITLE
26.2 port

### DIFF
--- a/common/src/main/java/com/github/theredbrain/bundleapi/predicate/item/CustomBundleContentsPredicate.java
+++ b/common/src/main/java/com/github/theredbrain/bundleapi/predicate/item/CustomBundleContentsPredicate.java
@@ -5,9 +5,9 @@ import com.github.theredbrain.bundleapi.component.type.CustomBundleContentsCompo
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import java.util.Optional;
-import net.minecraft.advancements.criterion.CollectionPredicate;
-import net.minecraft.advancements.criterion.ItemPredicate;
-import net.minecraft.advancements.criterion.SingleComponentItemPredicate;
+import net.minecraft.advancements.predicates.CollectionPredicate;
+import net.minecraft.advancements.predicates.ItemPredicate;
+import net.minecraft.advancements.predicates.SingleComponentItemPredicate;
 import net.minecraft.core.component.DataComponentType;
 import net.minecraft.world.item.ItemInstance;
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,11 +9,11 @@ archives_name = bundle-api
 enabled_platforms = fabric,neoforge
 
 # Minecraft properties
-minecraft_version = 26.1.2
+minecraft_version = 26.2
 # Supported game versions, oldest first (manifest minimum = first entry).
-minecraft_compat_versions = 26.1:26.1.1:26.1.2
+minecraft_compat_versions = 26.2
 
 # Dependencies
 fabric_loader_version = 0.19.3
-fabric_api_version = 0.155.2+26.1.2
-neoforge_version = 26.1.2.94
+fabric_api_version = 0.159.0+26.2
+neoforge_version = 26.2.0.75

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-Xmx2G
 org.gradle.parallel=true
 
 # Mod properties
-mod_version = 1.1.1
+mod_version = 1.1.1.001
 maven_group = com.github.TheRedBrain
 archives_name = bundle-api
 enabled_platforms = fabric,neoforge

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -11,7 +11,7 @@ authors = "TheRedBrain"
 description = '''
 An API for mods that allows easy addition of bundles with custom sizes and filtered content.
 '''
-logoFile = "icon.png"
+iconFile = "icon.png"
 
 [[dependencies.bundleapi]]
 modId = "neoforge"


### PR DESCRIPTION
Port to Minecraft 26.2, on top of #4 (26.1). Only the three commits after that are new here.

Nothing dramatic this time: version pins, the advancement predicate imports moved to `net.minecraft.advancements.predicates`, and `logoFile` -> `iconFile` in the neoforge manifest since 26.2 complains about the old key.

Builds and boots on both loaders, testmod included. 1.1.1 again, just for 26.2.